### PR TITLE
 more intuitive sym(double) behaviour

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -20,6 +20,10 @@ octsympy 2.0.0 (yyyy-mm-dd)
 
  *  Fixes for vpa and vpasolve: high precision should be more reliable.
 
+ *  Improve handling `sym(pi/3)` and other small fractions of pi.  It
+    works but you'll still get a warning and 2*sym(pi)/3 is really the
+    preferred approach!  `sym(-pi)` now works.
+
  *  On Windows, default to ascii rendering for now (until unicode
     is fixed in Octave on that platform).
 

--- a/inst/@sym/private/magic_double_str.m
+++ b/inst/@sym/private/magic_double_str.m
@@ -40,6 +40,8 @@ function [s, flag] = magic_double_str(x)
   % NOTE: yes, these are floating point equality checks!
   if (x == pi)
     s = 'pi';
+  elseif (x == -pi)
+    s = '-pi';
   elseif ((isinf(x)) && (x > 0))
     s = 'inf';
   elseif ((isinf(x)) && (x < 0))

--- a/inst/private/magic_double_str.m
+++ b/inst/private/magic_double_str.m
@@ -40,6 +40,8 @@ function [s, flag] = magic_double_str(x)
   % NOTE: yes, these are floating point equality checks!
   if (x == pi)
     s = 'pi';
+  elseif (x == -pi)
+    s = '-pi';
   elseif ((isinf(x)) && (x > 0))
     s = 'inf';
   elseif ((isinf(x)) && (x < 0))


### PR DESCRIPTION
You still shouldn't do this IMHO: sym(2)/3 is better than sym(2/3)
hence the warning.  Improve sym(-pi) and sym(2*pi/3).  Add tests.
Reword warning to make it clear heuristics are in use.

Fixes #190.