### PR TITLE
improve internal symbolic size support (and display)

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -30,7 +30,10 @@ octsympy 2.x.y (yyyy-mm-dd)
 
   * Improve symbolic sized matrices such as `A = sym('a', [n m])`.
     These are still experimental; they correspond to MatixSymbols in
-    SymPy and may need a recent SymPy development version.
+    SymPy and may need a recent SymPy development version.  For now,
+    the `size(A)` returns "1x1" although internally `NaN` is used for
+    symbolic-sized dimensions.  Enabling `size(A)` to return "NaNx3"
+    may occur later.
 
   * Drop python_cmd_string, which has been deprecated since v0.1.1.
 

--- a/inst/@sym/display.m
+++ b/inst/@sym/display.m
@@ -88,10 +88,15 @@ function display(x)
   elseif (is_matrix_symbol)
     nn = python_cmd('return _ins[0].rows,', x);
     mm = python_cmd('return _ins[0].cols,', x);
+    if (logical(nn == 0) || logical(mm == 0))
+      estr = 'empty ';
+    else
+      estr = '';
+    end
     numrstr = strtrim(disp(nn, 'flat'));
     numcstr = strtrim(disp(mm, 'flat'));
-    n = fprintf ('%s = (%s) %s (%s%s%s symbolic-sized matrix)', name, ...
-                 class (x), strtrim(disp(x)), numrstr, timesstr, numcstr);
+    n = fprintf ('%s = (%s) %s (%s%s%s%s symbolic-sized matrix)', name, ...
+                 class (x), strtrim(disp(x)), estr, numrstr, timesstr, numcstr);
     if (unicode_dec)
       n = n - 1;  % FIXME: b/c times unicode is two bytes
     end

--- a/inst/@sym/display.m
+++ b/inst/@sym/display.m
@@ -89,7 +89,15 @@ function display(x)
     end
 
   elseif (is_matrix_symbol)
-    [nn, mm] = python_cmd('return (_ins[0].rows, _ins[0].cols)', x);
+    %if (any(isnan(d)))  % may not tell the truth
+    if (any(isnan(x.size)))
+      [nn, mm] = python_cmd('return (_ins[0].rows, _ins[0].cols)', x);
+      numrstr = strtrim(disp(nn, 'flat'));
+      numcstr = strtrim(disp(mm, 'flat'));
+    else
+      numrstr = num2str(d(1));
+      numcstr = num2str(d(2));
+    end
     if (logical(nn == 0) || logical(mm == 0))
       estr = 'empty ';
     else

--- a/inst/@sym/display.m
+++ b/inst/@sym/display.m
@@ -62,7 +62,13 @@ function display(x)
   name = priv_disp_name(x, inputname (1));
   d = size (x);
 
-  if (isscalar (x))
+  if (strncmp(char(x), 'MatrixSymbol', 12))
+    is_matrix_symbol = true;
+  else
+    is_matrix_symbol = false;
+  end
+
+  if (isscalar (x)) && (~is_matrix_symbol)
     n = fprintf ('%s = (%s)', name, class (x));
     s = strtrim(disp(x));
     hasnewlines = strfind(s, newl);
@@ -78,6 +84,19 @@ function display(x)
       disp(x)
       if (loose), fprintf ('\n'); end
     end
+
+  elseif (is_matrix_symbol)
+    nn = python_cmd('return _ins[0].rows,', x);
+    mm = python_cmd('return _ins[0].cols,', x);
+    numrstr = strtrim(disp(nn, 'flat'));
+    numcstr = strtrim(disp(mm, 'flat'));
+    n = fprintf ('%s = (%s) %s (%s%s%s symbolic-sized matrix)', name, ...
+                 class (x), strtrim(disp(x)), numrstr, timesstr, numcstr);
+    if (unicode_dec)
+      n = n - 1;  % FIXME: b/c times unicode is two bytes
+    end
+    snippet_of_sympy (x, 7, term_width - n, unicode_dec)
+
 
 
   elseif (isempty (x))

--- a/inst/@sym/display.m
+++ b/inst/@sym/display.m
@@ -62,10 +62,13 @@ function display(x)
   name = priv_disp_name(x, inputname (1));
   d = size (x);
 
-  if (strncmp(char(x), 'MatrixSymbol', 12))
-    is_matrix_symbol = true;
-  else
-    is_matrix_symbol = false;
+  % sort of isinstance(x, MatrixExpr) but cheaper
+  is_matrix_symbol = false;
+  matexprlist = {'MatrixSymbol' 'MatMul' 'MatAdd' 'MatMul'};
+  for i=1:length(matexprlist)
+    if (strncmp(char(x), matexprlist{i}, length(matexprlist{i})))
+      is_matrix_symbol = true;
+    end
   end
 
   if (isscalar (x)) && (~is_matrix_symbol)
@@ -94,7 +97,7 @@ function display(x)
     end
     numrstr = strtrim(disp(nn, 'flat'));
     numcstr = strtrim(disp(mm, 'flat'));
-    n = fprintf ('%s = (%s) %s (%s%s%s%s symbolic-sized matrix)', name, ...
+    n = fprintf ('%s = (%s) %s (%s%s%s%s matrix expression)', name, ...
                  class (x), strtrim(disp(x)), estr, numrstr, timesstr, numcstr);
     if (unicode_dec)
       n = n - 1;  % FIXME: b/c times unicode is two bytes

--- a/inst/@sym/display.m
+++ b/inst/@sym/display.m
@@ -1,4 +1,4 @@
-%% Copyright (C) 2014 Colin B. Macdonald
+%% Copyright (C) 2014, 2015 Colin B. Macdonald
 %%
 %% This file is part of OctSymPy.
 %%
@@ -86,8 +86,7 @@ function display(x)
     end
 
   elseif (is_matrix_symbol)
-    nn = python_cmd('return _ins[0].rows,', x);
-    mm = python_cmd('return _ins[0].cols,', x);
+    [nn, mm] = python_cmd('return (_ins[0].rows, _ins[0].cols)', x);
     if (logical(nn == 0) || logical(mm == 0))
       estr = 'empty ';
     else

--- a/inst/@sym/isempty.m
+++ b/inst/@sym/isempty.m
@@ -61,3 +61,13 @@ end
 %! assert (isempty (A))
 %! A = sym(ones(3,0));
 %! assert (isempty (A))
+
+%!test
+%! % empty symbolic-size matrices
+%! syms n integer
+%! A = sym('A', [3 n]);
+%! assert (~isempty (A))
+%! A = sym('A', [0 n]);
+%! assert (isempty (A))
+%! A = sym('A', [n 0]);
+%! assert (isempty (A))

--- a/inst/@sym/isempty.m
+++ b/inst/@sym/isempty.m
@@ -69,6 +69,11 @@ end
 %! syms n integer
 %! A = sym('A', [3 n]);
 %! assert (~isempty (A))
+
+%!xtest
+%! % empty symbolic-size matrices
+%! % FIXME: will fail until size stop lying by saying 1x1
+%! syms n integer
 %! A = sym('A', [0 n]);
 %! assert (isempty (A))
 %! A = sym('A', [n 0]);

--- a/inst/@sym/isempty.m
+++ b/inst/@sym/isempty.m
@@ -55,6 +55,8 @@ end
 %!test assert ( isa (se, 'sym'))
 %!test assert ( isequal (se, 10))
 
+%!shared
+
 %!test
 %! % empty matrices
 %! A = sym('A', [3 0]);
@@ -63,7 +65,7 @@ end
 %! assert (isempty (A))
 
 %!test
-%! % empty symbolic-size matrices
+%! % non-empty symbolic-size matrices
 %! syms n integer
 %! A = sym('A', [3 n]);
 %! assert (~isempty (A))

--- a/inst/@sym/size.m
+++ b/inst/@sym/size.m
@@ -34,6 +34,15 @@ function [n, m] = size(x, dim)
 
   n = x.size;
 
+  % FIXME: for now, we artificially force symbolic sized objects
+  % (where one or more dimension is recorded as NaN) to be 1x1.
+  % This effects MatrixSymbol and MatrixExpr.  See Issue #159.
+  if (any(isnan(n)))
+    n = [1 1];
+  end
+  % Alternatively:
+  %n(isnan(n)) = 1;
+
   if (nargin == 2) && (nargout == 2)
     error('size: invalid call')
   elseif (nargout == 2)
@@ -83,7 +92,7 @@ end
 %! m = size(a, 2);
 %! assert (m == 1)
 
-%!test
+%!xtest
 %! % symbolic-size matrices
 %! syms n m integer
 %! A = sym('A', [n m]);
@@ -92,18 +101,18 @@ end
 %! assert (isnumeric(d))
 %! assert (isequaln (d, [NaN NaN]))
 
-%!test
+%!xtest
 %! % half-symbolic-size matrices
+%! % FIXME: will fail until size stop lying by saying 1x1
 %! syms n integer
 %! A = sym('A', [n 3]);
 %! assert (isequaln (size(A), [NaN 3]))
 %! A = sym('A', [4 n]);
 %! assert (isequaln (size(A), [4 NaN]))
 
-%!test
+%!xtest
 %! % half-symbolic-size empty matrices
+%! % FIXME: will fail until size stop lying by saying 1x1
 %! syms n integer
 %! A = sym('A', [n 0]);
-%! d = size(A);
 %! assert (isequaln (size(A), [NaN 0]))
-%! assert (isempty(A))

--- a/inst/@sym/size.m
+++ b/inst/@sym/size.m
@@ -1,4 +1,4 @@
-%% Copyright (C) 2014 Colin B. Macdonald
+%% Copyright (C) 2014, 2015 Colin B. Macdonald
 %%
 %% This file is part of OctSymPy.
 %%
@@ -30,7 +30,10 @@
 
 function [n, m] = size(x, dim)
 
+  % Note: symbolic sized matrices should return double, not sym/string.
+
   n = x.size;
+
   if (nargin == 2) && (nargout == 2)
     error('size: invalid call')
   elseif (nargout == 2)
@@ -79,3 +82,28 @@ end
 %! assert (n == 3)
 %! m = size(a, 2);
 %! assert (m == 1)
+
+%!test
+%! % symbolic-size matrices
+%! syms n m integer
+%! A = sym('A', [n m]);
+%! d = size(A);
+%! assert (~isa(d, 'sym'))
+%! assert (isnumeric(d))
+%! assert (isequaln (d, [NaN NaN]))
+
+%!test
+%! % half-symbolic-size matrices
+%! syms n integer
+%! A = sym('A', [n 3]);
+%! assert (isequaln (size(A), [NaN 3]))
+%! A = sym('A', [4 n]);
+%! assert (isequaln (size(A), [4 NaN]))
+
+%!test
+%! % half-symbolic-size empty matrices
+%! syms n integer
+%! A = sym('A', [n 0]);
+%! d = size(A);
+%! assert (isequaln (size(A), [NaN 0]))
+%! assert (isempty(A))

--- a/inst/@sym/trace.m
+++ b/inst/@sym/trace.m
@@ -30,7 +30,7 @@ function z = trace(x)
   cmd = { 'x, = _ins'
           'if not x.is_Matrix:'
           '    x = sp.Matrix([[x]])'
-          'return x.trace(),' };
+          'return sp.trace(x),' };
 
   z = python_cmd (cmd, x);
 

--- a/inst/private/extractblock.m
+++ b/inst/private/extractblock.m
@@ -134,11 +134,8 @@ function r = process_item(item)
       r = strcmpi(C{2}, 'true');
     case OCTCODE_SYM
       assert(M == 6)
-      %warning('FIXME: wip?  more error checking')
       sz1 = str2double(C{3});
       sz2 = str2double(C{4});
-      assert(~isnan(sz1));
-      assert(~isnan(sz2));
       % fixme: should we use <item>'s for these not raw <f>?
       str = str_post_xml_filter(C{2});
       flat = str_post_xml_filter(C{5});

--- a/inst/private/python_header.py
+++ b/inst/private/python_header.py
@@ -180,8 +180,8 @@ try:
             elif isinstance(x, (sp.Expr, Boolean)):
                 _d = (1, 1)
             elif isinstance(x, sp.MatrixExpr):
-                # FIXME: play with x.shape instead
-                _d = (1, 1)
+                # nan for symbolic size
+                _d = [float('nan') if (isinstance(r, sp.Basic) and not r.is_Integer) else r for r in x.shape]
             else:
                 dbout("Treating unexpected SymPy obj as scalar: " + str(type(x)))
                 _d = (1,1)


### PR DESCRIPTION
MatrixExpr still have `size(A)` return `[1 1]` but only because of a hack in `size.m`.  Will be easy to enable "NaNx3" support later if wanted.