### PR TITLE
New functions for Catalan and Euler-Mascheroni mathematical constants.

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -1,6 +1,11 @@
 octsympy 2.1.1.dev
 ==================
 
+  * New commands:
+
+          catalan
+          eulergamma
+
   * Documentation improvements: assumptions.
 
   * Bug fixes: #201 (assumptions, symvar and symbolic matrix power).

--- a/inst/catalan.m
+++ b/inst/catalan.m
@@ -35,3 +35,5 @@ function g = catalan ()
   g = python_cmd ('return sympy.S.Catalan,');
 end
 
+%!assert (double (catalan ()) > 0.915965594177)
+%!assert (double (catalan ()) < 0.915965594178)

--- a/inst/catalan.m
+++ b/inst/catalan.m
@@ -1,0 +1,37 @@
+%% Copyright (C) 2015 Carnë Draug
+%%
+%% This file is part of OctSymPy.
+%%
+%% OctSymPy is free software; you can redistribute it and/or modify
+%% it under the terms of the GNU General Public License as published
+%% by the Free Software Foundation; either version 3 of the License,
+%% or (at your option) any later version.
+%%
+%% This software is distributed in the hope that it will be useful,
+%% but WITHOUT ANY WARRANTY; without even the implied warranty
+%% of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See
+%% the GNU General Public License for more details.
+%%
+%% You should have received a copy of the GNU General Public
+%% License along with this software; see the file COPYING.
+%% If not, see <http://www.gnu.org/licenses/>.
+
+%% -*- texinfo -*-
+%% @deftypefn {Function File} {} catalan ()
+%% Return Catalan constant.
+%%
+%% @example
+%% vpa (catalan ())
+%% @result {} (sym) 0.91596559417721901505460351493238
+%% @end example
+%%
+%% @seealso{eulergamma}
+%% @end deftypefn
+
+%% Author: Carnë Draug
+%% Keywords: symbolic, constants
+
+function g = catalan ()
+  g = python_cmd ('return sympy.S.Catalan,');
+end
+

--- a/inst/eulergamma.m
+++ b/inst/eulergamma.m
@@ -21,7 +21,7 @@
 %% Return Euler-Mascheroni constant.
 %%
 %% @example
-%% vpa (catalan ())
+%% vpa (eulergamma ())
 %% @result {} (sym) 0.57721566490153286060651209008240
 %% @end example
 %%

--- a/inst/eulergamma.m
+++ b/inst/eulergamma.m
@@ -35,3 +35,5 @@ function g = eulergamma ()
   g = python_cmd ('return sympy.S.EulerGamma,');
 end
 
+%!assert (double (eulergamma ()) > 0.577215664901)
+%!assert (double (eulergamma ()) < 0.577215664902)

--- a/inst/eulergamma.m
+++ b/inst/eulergamma.m
@@ -1,0 +1,37 @@
+%% Copyright (C) 2015 Carnë Draug
+%%
+%% This file is part of OctSymPy.
+%%
+%% OctSymPy is free software; you can redistribute it and/or modify
+%% it under the terms of the GNU General Public License as published
+%% by the Free Software Foundation; either version 3 of the License,
+%% or (at your option) any later version.
+%%
+%% This software is distributed in the hope that it will be useful,
+%% but WITHOUT ANY WARRANTY; without even the implied warranty
+%% of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See
+%% the GNU General Public License for more details.
+%%
+%% You should have received a copy of the GNU General Public
+%% License along with this software; see the file COPYING.
+%% If not, see <http://www.gnu.org/licenses/>.
+
+%% -*- texinfo -*-
+%% @deftypefn {Function File} {} eulergamma ()
+%% Return Euler-Mascheroni constant.
+%%
+%% @example
+%% vpa (catalan ())
+%% @result {} (sym) 0.57721566490153286060651209008240
+%% @end example
+%%
+%% @seealso{catalan}
+%% @end deftypefn
+
+%% Author: Carnë Draug
+%% Keywords: symbolic, constants
+
+function g = eulergamma ()
+  g = python_cmd ('return sympy.S.EulerGamma,');
+end
+


### PR DESCRIPTION
Adds two new functions for the symbolic package. I also have a python script to generate them automatically but in the end I thought that although quite simple, the script would be overkill.