### PR TITLE
Add "sympref quiet on" option to partially suppress messages

### DIFF
--- a/inst/private/python_ipc_popen2.m
+++ b/inst/private/python_ipc_popen2.m
@@ -5,9 +5,13 @@ function [A, out] = python_ipc_popen2(what, cmd, varargin)
 
   py_startup_timeout = 30;  % seconds
 
+  verbose = ~sympref('quiet');
+
   if (strcmp(what, 'reset'))
     if (~isempty(pid))
-      disp('Closing the Python pipe...');
+      if (verbose)
+        disp('Closing the Python pipe...');
+      end
     end
     if (~isempty(fin))
       t = fclose(fin); fin = [];
@@ -31,18 +35,20 @@ function [A, out] = python_ipc_popen2(what, cmd, varargin)
 
   newl = sprintf('\n');
 
-  vstr = sympref('version');
-
   if isempty(pid)
-    disp(['OctSymPy v' vstr ': this is free software without warranty, see source.'])
-    disp('Initializing communication with SymPy using a popen2() pipe.')
-
+    if (verbose)
+      fprintf('OctSymPy v%s: this is free software without warranty, see source.', ...
+              sympref('version'))
+      disp('Initializing communication with SymPy using a popen2() pipe.')
+    end
     pyexec = sympref('python');
     if (isempty(pyexec))
       if (ispc() && ~isunix())
         % Octave popen2 on Windows can't tolerate stderr output
         % https://savannah.gnu.org/bugs/?43036
-        disp(['Detected Windows: using "winwrapy.bat" to workaround Octave bug #43036'])
+        if (verbose)
+          disp('Detected Windows: using "winwrapy.bat" to workaround Octave bug #43036')
+        end
         pyexec = 'winwrapy.bat';
       else
         pyexec = 'python';
@@ -51,8 +57,10 @@ function [A, out] = python_ipc_popen2(what, cmd, varargin)
     % perhaps the the '-i' is not always wanted?
     [fin, fout, pid] = popen2 (pyexec, '-i');
 
-    fprintf('Some output from the Python subprocess (pid %d) might appear next.\n', pid)
-    %fprintf('Technical details: fin = %d, fout = %d, pid = %d.\n', fin, fout, pid)
+    if (verbose)
+      fprintf('Some output from the Python subprocess (pid %d) might appear next.\n', pid)
+      %fprintf('Technical details: fin = %d, fout = %d, pid = %d.\n', fin, fout, pid)
+    end
     fflush (stdout);
 
     if (pid < 0)
@@ -86,10 +94,12 @@ function [A, out] = python_ipc_popen2(what, cmd, varargin)
       out
       error('ipc_popen2: something has gone wrong in starting python')
     else
-      disp(['OctSymPy: ' A{1} '  SymPy v' A{2} '.']);
-      % on unix we're seen this on stderr
-      if (ispc() && ~isunix())
-        disp(['Python ' strrep(A{3}, newl, '')])
+      if (verbose)
+        disp(['OctSymPy: ' A{1} '  SymPy v' A{2} '.']);
+        % on unix we're seen this on stderr
+        if (ispc() && ~isunix())
+          disp(['Python ' strrep(A{3}, newl, '')])
+        end
       end
     end
   end

--- a/inst/private/python_ipc_sysoneline.m
+++ b/inst/private/python_ipc_sysoneline.m
@@ -14,10 +14,11 @@ function [A, out] = python_ipc_sysoneline(what, cmd, mktmpfile, varargin)
     error('unsupported command')
   end
 
-  vstr = sympref('version');
+  verbose = ~sympref('quiet');
 
-  if (isempty(show_msg))
-    disp(['OctSymPy v' vstr ': this is free software without warranty, see source.'])
+  if (verbose && isempty(show_msg))
+    fprintf('OctSymPy v%s: this is free software without warranty, see source.', ...
+            sympref('version'))
     disp('Using system()-based communication with Python [sysoneline].')
     disp('Warning: this will be *SLOW*.  Every round-trip involves executing a')
     disp('new Python process and many operations involve several round-trips.')

--- a/inst/private/python_ipc_system.m
+++ b/inst/private/python_ipc_system.m
@@ -14,9 +14,10 @@ function [A, out] = python_ipc_system(what, cmd, mktmpfile, varargin)
     error('unsupported command')
   end
 
-  vstr = sympref('version');
+  verbose = ~sympref('quiet');
 
-  if (isempty(show_msg))
+  if (verbose && isempty(show_msg))
+    vstr = sympref('version');
     disp(['OctSymPy v' vstr ': this is free software without warranty, see source.'])
     disp('You are using the slower system() communications with SymPy.')
     disp('Warning: this will be *SLOW*.  Every round-trip involves executing a')

--- a/inst/sympref.m
+++ b/inst/sympref.m
@@ -136,6 +136,15 @@
 %% @end group
 %% @end example
 %%
+%% Be @strong{quiet} by minimizing startup and diagnostics messages:
+%% @example
+%% @group
+%% >> sympref quiet
+%%    @result{} ans = 0
+%% >> sympref quiet on
+%% >> sympref quiet default
+%% @end group
+%% @end example
 %%
 %% Report the @strong{version} number:
 %% @example
@@ -171,6 +180,7 @@ function varargout = sympref(cmd, arg)
       sympref ('display', 'default')
       sympref ('digits', 'default')
       sympref ('snippet', 'default')
+      sympref ('quiet', 'default')
 
     case 'version'
       assert (nargin == 1)
@@ -218,6 +228,17 @@ function varargout = sympref(cmd, arg)
 	else
           settings.snippet = tf_from_input(arg);
 	end
+      end
+
+    case 'quiet'
+      if (nargin == 1)
+        varargout{1} = settings.quiet;
+      else
+        if (strcmpi(arg, 'default'))
+          settings.quiet = false;
+        else
+          settings.quiet = tf_from_input(arg);
+        end
       end
 
     case 'python'
@@ -302,6 +323,12 @@ function r = tf_from_input(s)
   end
 end
 
+
+%!test
+%! % test quiet, side effect of making following tests a bit less noisy!
+%! sympref quiet on
+%! a = sympref('quiet');
+%! assert(a == 1)
 
 %!test
 %! % system should work on all system, but just runs sysoneline on windows


### PR DESCRIPTION
Not yet possible (I think) to make Python shutup during startup
but this should minimize the messages we output!

Fixes #273.