### PR TITLE
drop an ambiguous test

### DIFF
--- a/inst/@sym/ismember.m
+++ b/inst/@sym/ismember.m
@@ -88,7 +88,7 @@ end
 
 %!test
 %! % set
-%! syms x
+%! syms x real
 %! %FIXME: replace with finiteset later
 %! %S = finiteset(2, sym(pi), x)
 %! S = interval(sym(2),2) + interval(sym(pi),pi) + interval(x,x);
@@ -97,11 +97,5 @@ end
 %!test
 %! % set with positive symbol
 %! syms x positive
-%! S = interval(sym(2),2) + interval(sym(pi),pi) + interval(x,x);
-%! assert (~ismember (-1, S))
-
-%!error
-%! % set with symbol can be indeterminant
-%! syms x
 %! S = interval(sym(2),2) + interval(sym(pi),pi) + interval(x,x);
 %! assert (~ismember (-1, S))


### PR DESCRIPTION
I changed my mind: SymPy 0.7.6.1 gets it wrong.  SymPy 0.7.7-dev
raises an error.  But perhaps SymPy should say None: its usual
answer to "maybe"...  Anyway, don't test for it here!