### PR TITLE
enable normal return python

### DIFF
--- a/inst/python_cmd.m
+++ b/inst/python_cmd.m
@@ -38,22 +38,7 @@
 %% @end group
 %% @end example
 %%
-%% The inputs will be in a list called '_ins'.  The command should
-%% end by outputing a tuple of return arguments.
-%% If you have just one return value, you probably want to append
-%% an extra comma.  Either of these approaches will work:
-%% @example
-%% @group
-%% >> cmd = '(x,y) = _ins; return (x+y,)';
-%% >> a = python_cmd (cmd, x, y)
-%%    @result{} a =  12
-%% >> cmd = '(x,y) = _ins; return x+y,';
-%% >> a = python_cmd (cmd, x, y)
-%%    @result{} a =  12
-%% @end group
-%% @end example
-%% (Python gurus will know why).
-%%
+%% The inputs will be in a list called '_ins'.
 %% Instead of @code{return}, you can append to the Python list
 %% @code{_outs}:
 %% @example

--- a/inst/python_cmd.m
+++ b/inst/python_cmd.m
@@ -340,3 +340,11 @@ end
 %! cmd = 'd = dict(); d["a"] = 6; d["b"] = 10; return d,';
 %! d = python_cmd (cmd);
 %! assert (d.a == 6 && d.b == 10)
+
+%!test
+%! r = python_cmd ("return 6");
+%! assert (isequal (r, 6))
+
+%!test
+%! r = python_cmd ('return "Hi"');
+%! assert (strcmp (r, 'Hi'))

--- a/inst/python_cmd.m
+++ b/inst/python_cmd.m
@@ -149,16 +149,7 @@ function varargout = python_cmd(cmd, varargin)
   [A, db] = python_ipc_driver('run', cmd, varargin{:});
 
   if (~iscell(A))
-    disp('')
-    disp('The python_cmd function received something unexpected (not a cell array)');
-    disp('from the communication layer.  This can happen if the block of python code');
-    disp('failed to return a tuple (you should use "return x," not "return x").  But');
-    disp('it can also indicate a communication problem so we will do "sympref reset".');
-    disp('For debugging, the returned value was:');
-    disp(A)
-    % Python state undefined, so reset it (overkill for nostateful ipc)
-    sympref reset
-    error('OctSymPy:python_cmd:unexpected', 'python_cmd: unexpected return')
+    A={A};
   end
 
   if (strcmp(A{1}, 'COMMAND_ERROR_PYTHON'))


### PR DESCRIPTION
you know, lets try.

```
>> python_cmd("return 'hi'")
warning: number of outputs don't match, was this intentional?
warning: called from
    python_cmd at line 170 column 5
ans = hi
```

:O num 333