### PR TITLE
For large integers, enable the "rat()" heuristics warning

### DIFF
--- a/inst/@sym/private/magic_double_str.m
+++ b/inst/@sym/private/magic_double_str.m
@@ -1,4 +1,4 @@
-%% Copyright (C) 2015 Colin B. Macdonald
+%% Copyright (C) 2015, 2016 Colin B. Macdonald
 %%
 %% This file is part of OctSymPy.
 %%
@@ -48,7 +48,8 @@ function [s, flag] = magic_double_str(x)
     s = '-inf';
   elseif (isnan(x))
     s = 'nan';
-  elseif (isreal(x) && (mod(x,1) == 0))   % is integer
+  elseif (isreal(x) && (abs(x) < 1e15) && (mod(x,1) == 0))
+    % special treatment for "small" integers
     s = num2str(x);  % better than sprintf('%d', large)
   else
     s = '';

--- a/inst/@sym/sym.m
+++ b/inst/@sym/sym.m
@@ -1,4 +1,4 @@
-%% Copyright (C) 2014, 2015 Colin B. Macdonald
+%% Copyright (C) 2014-2016 Colin B. Macdonald
 %%
 %% This file is part of OctSymPy.
 %%
@@ -362,6 +362,7 @@ function s = sym(x, varargin)
 
 end
 
+
 %!test
 %! % integers
 %! x = sym('2');
@@ -645,6 +646,11 @@ end
 %! % E can be a sym not just exp(sym(1))
 %! syms E
 %! assert (~logical (E == exp(sym(1))))
+
+%!warning <heuristics for double-precision> sym(1e16);
+%!warning <heuristics for double-precision> sym(-1e16);
+%!warning <heuristics for double-precision> sym(10.33);
+%!warning <heuristics for double-precision> sym(-5.23);
 
 %!error <assumption is not supported>
 %! x = sym('x', 'positive2');

--- a/inst/private/magic_double_str.m
+++ b/inst/private/magic_double_str.m
@@ -1,4 +1,4 @@
-%% Copyright (C) 2015 Colin B. Macdonald
+%% Copyright (C) 2015, 2016 Colin B. Macdonald
 %%
 %% This file is part of OctSymPy.
 %%
@@ -48,7 +48,8 @@ function [s, flag] = magic_double_str(x)
     s = '-inf';
   elseif (isnan(x))
     s = 'nan';
-  elseif (isreal(x) && (mod(x,1) == 0))   % is integer
+  elseif (isreal(x) && (abs(x) < 1e15) && (mod(x,1) == 0))
+    % special treatment for "small" integers
     s = num2str(x);  % better than sprintf('%d', large)
   else
     s = '';


### PR DESCRIPTION
This is because large integers represented in double-prec, cannot
be reliably identified as integer, nor is their value precise
enough (for example 1e16 + 1 == 1e16).  We give the same warning
that `sym(10.3)` gives.  The best way to enter large integer values
is `sym(10)^16`.

Fixes #361