### PR TITLE
Support PYTHON env variable

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -29,6 +29,9 @@ octsympy 2.4.0-dev
   * Add spherical Bessel functions: these are called `besseljn` and
     `besselyn` (for now, subject to change).  Thanks to Utkarsh Gautam.
 
+  * The environment variable `PYTHON` can control which Python executable
+    is used.  Changing the Python executable should work on Windows.
+
 
 
 octsympy 2.3.0 (2016-04-08)

--- a/bin/winwrapy.bat
+++ b/bin/winwrapy.bat
@@ -5,7 +5,7 @@ REM This is a workaround as Octave for Windows cannot tolerate stderr from a pop
 REM subprocess: see [this bug report](https://savannah.gnu.org/bugs/?43036).
 REM You'll need to edit this script if your python is called something else.
 
-python.exe -i 2> NUL
+%1 -i 2> NUL
 
 REM If you are using the windows bundle for octsympy then "octpy.exe" will be used.
 REM It is [available online](http://www.orbitals.com/programs/pyexe.html)

--- a/inst/private/python_ipc_popen2.m
+++ b/inst/private/python_ipc_popen2.m
@@ -81,10 +81,10 @@ function [A, info] = python_ipc_popen2(what, cmd, varargin)
       if (verbose)
         disp('Detected Windows: using "winwrapy.bat" to workaround Octave bug #43036')
       end
-      pyexec = 'winwrapy.bat';
+      [fin, fout, pid] = popen2 ('winwrapy.bat', pyexec);
+    else
+      [fin, fout, pid] = popen2 (pyexec, '-i');
     end
-    % perhaps the the '-i' is not always wanted?
-    [fin, fout, pid] = popen2 (pyexec, '-i');
 
     if (verbose)
       fprintf('Some output from the Python subprocess (pid %d) might appear next.\n', pid)

--- a/inst/private/python_ipc_popen2.m
+++ b/inst/private/python_ipc_popen2.m
@@ -75,17 +75,13 @@ function [A, info] = python_ipc_popen2(what, cmd, varargin)
       disp('Initializing communication with SymPy using a popen2() pipe.')
     end
     pyexec = sympref('python');
-    if (isempty(pyexec))
-      if (ispc() && ~isunix())
-        % Octave popen2 on Windows can't tolerate stderr output
-        % https://savannah.gnu.org/bugs/?43036
-        if (verbose)
-          disp('Detected Windows: using "winwrapy.bat" to workaround Octave bug #43036')
-        end
-        pyexec = 'winwrapy.bat';
-      else
-        pyexec = 'python';
+    if (ispc() && ~isunix())
+      % Octave popen2 on Windows can't tolerate stderr output
+      % https://savannah.gnu.org/bugs/?43036
+      if (verbose)
+        disp('Detected Windows: using "winwrapy.bat" to workaround Octave bug #43036')
       end
+      pyexec = 'winwrapy.bat';
     end
     % perhaps the the '-i' is not always wanted?
     [fin, fout, pid] = popen2 (pyexec, '-i');

--- a/inst/private/python_ipc_sysoneline.m
+++ b/inst/private/python_ipc_sysoneline.m
@@ -100,9 +100,6 @@ function [A, info] = python_ipc_sysoneline(what, cmd, mktmpfile, varargin)
   s3 = ['exec(\"' s '\");'];
 
   pyexec = sympref('python');
-  if (isempty(pyexec))
-    pyexec = 'python';
-  end
 
   bigs = [headers s1 s2 s3];
 

--- a/inst/private/python_ipc_system.m
+++ b/inst/private/python_ipc_system.m
@@ -77,9 +77,6 @@ function [A, info] = python_ipc_system(what, cmd, mktmpfile, varargin)
   s = strjoin([s_in cmd s_out], newl);
 
   pyexec = sympref('python');
-  if (isempty(pyexec))
-    pyexec = 'python';
-  end
 
   %% FIXME: Issue #63: with new regexp code on Matlab
   % workaround:

--- a/inst/sympref.m
+++ b/inst/sympref.m
@@ -262,7 +262,17 @@ function varargout = sympref(cmd, arg)
 
     case 'python'
       if (nargin == 1)
-        varargout{1} = settings.whichpython;
+        DEFAULTPYTHON = 'python';
+        if isempty(settings.whichpython)
+          pyenv = getenv('PYTHON');
+          if (isempty(pyenv))
+            varargout{1} = DEFAULTPYTHON;
+          else
+            varargout{1} = pyenv;
+          end
+        else
+          varargout{1} = settings.whichpython;
+        end
       elseif (isempty(arg) || strcmp(arg,'[]'))
         settings.whichpython = '';
         sympref('reset')

--- a/inst/sympref.m
+++ b/inst/sympref.m
@@ -22,7 +22,7 @@
 %% @deftypefnx {Function File} {@var{r} =} sympref (@var{cmd})
 %% @deftypefnx {Function File} {} sympref @var{cmd}
 %% @deftypefnx {Function File} {} sympref @var{cmd} @var{args}
-%% Preferences for the OctSymPy symbolic computing package.
+%% Preferences for the Symbolic package.
 %%
 %% @code{sympref} can set or get various preferences and
 %% configurations.  The various choices for @var{cmd} and
@@ -89,16 +89,16 @@
 %%
 %% sympref display unicode
 %% sin(x/2)
-%%    @result{} (sym)
-%%           ⎛x⎞
-%%        sin⎜─⎟
-%%           ⎝2⎠
+%%   @result{} (sym)
+%%          ⎛x⎞
+%%       sin⎜─⎟
+%%          ⎝2⎠
 %%
 %% sympref display default
 %% @end group
 %% @end example
 %%
-%% By default OctSymPy uses the unicode pretty printer to display
+%% By default, a unicode pretty printer is used to display
 %% symbolic expressions.  If that doesn't work (e.g., if you
 %% see @code{?} characters) then try the @code{ascii} option.
 %%
@@ -313,11 +313,11 @@ function varargout = sympref(cmd, arg)
         settings.ipc = arg;
         switch arg
           case 'default'
-            msg = 'Choosing the default [autodetect] octsympy communication mechanism';
+            msg = 'Choosing the default [autodetect] communication mechanism';
           case 'system'
-            msg = 'Forcing the system() octsympy communication mechanism';
+            msg = 'Forcing the system() communication mechanism';
           case 'popen2'
-            msg = 'Forcing the popen2() octsympy communication mechanism';
+            msg = 'Forcing the popen2() communication mechanism';
           case 'systmpfile'
             msg = 'Forcing systmpfile ipc: warning: this is for debugging';
           case 'sysoneline'
@@ -334,7 +334,7 @@ function varargout = sympref(cmd, arg)
     case 'reset'
       verbose = ~sympref('quiet');
       if (verbose)
-        disp('Resetting the octsympy communication mechanism');
+        disp('Resetting the communication mechanism');
       end
       r = python_ipc_driver('reset', []);
 

--- a/inst/sympref.m
+++ b/inst/sympref.m
@@ -29,18 +29,41 @@
 %% @var{args} are documented below.
 %%
 %%
-%% @strong{Python executable} path/command:
+%% Get the current @strong{Python executable} path/name:
+%% @example
+%% @comment doctest: +SKIP
+%% sympref python
+%%   @result{} ans = python
+%% @end example
 %%
+%% By default, this value is first taken from an environment
+%% variable called @code{PYTHON}.  This can be configured
+%% in the OS or it can be set within Octave using:
+%% @example
+%% @comment doctest: +SKIP
+%% setenv('PYTHON', '/usr/bin/python')
+%% sympref reset
+%% @end example
+%%
+%% Alternatively, the environment variable can be overriden by:
 %% @example
 %% @group
-%% sympref python '/usr/bin/python'           % doctest: +SKIP
-%% sympref python 'C:\Python\python.exe'      % doctest: +SKIP
-%% sympref python 'N:\myprogs\py.exe'         % doctest: +SKIP
+%% @comment doctest: +SKIP
+%% sympref python '/usr/bin/python'
+%% sympref python 'C:\Python\python.exe'
 %% @end group
 %% @end example
 %%
-%% Default is an empty string; in which case OctSymPy just runs
-%% @code{python} and assumes the path is set appropriately.
+%% Finally, if neither is set, the package typically assumes the
+%% command is simply @code{python}.
+%%
+%% The default behaviour can be restored using either:
+%% @example
+%% @comment doctest: +SKIP
+%% sympref python []
+%% sympref('python', '')
+%% @end example
+%% or with `sympref defaults` as noted below.
 %%
 %%
 %% @strong{Display} of syms:

--- a/make_windows_package.sh
+++ b/make_windows_package.sh
@@ -66,9 +66,8 @@ cp ${PYEXEREADME} ${WINDIR}/README.pyexe.txt
 
 # change default python to octpy.exe
 echo "making default python octpy.exe"
-sed -i "s/pyexec = 'python'/pyexec = 'octpy.exe'/" ${WINDIR}/inst/private/python_ipc_sysoneline.m
-sed -i "s/pyexec = 'python'/pyexec = 'octpy.exe'/" ${WINDIR}/inst/private/python_ipc_system.m
 sed -i 's/python.exe/octpy.exe/g' ${WINDIR}/bin/winwrapy.bat
+sed -i "s/DEFAULTPYTHON = 'python'/DEFAULTPYTHON = 'octpy.exe'/" ${WINDIR}/inst/sympref.m
 
 # sympy and mpmath
 cp -pR ${SYMPY}/sympy ${WINDIR}/bin/ || exit 1

--- a/make_windows_package.sh
+++ b/make_windows_package.sh
@@ -66,7 +66,6 @@ cp ${PYEXEREADME} ${WINDIR}/README.pyexe.txt
 
 # change default python to octpy.exe
 echo "making default python octpy.exe"
-sed -i 's/python.exe/octpy.exe/g' ${WINDIR}/bin/winwrapy.bat
 sed -i "s/DEFAULTPYTHON = 'python'/DEFAULTPYTHON = 'octpy.exe'/" ${WINDIR}/inst/sympref.m
 
 # sympy and mpmath


### PR DESCRIPTION
Fix for #415.

@genuinelucifer are you able to test this on windows?  The python executable name is passed to `winwrapy.bat` as a command line argument: should work but I've not tested it!