### PR TITLE
Check that we have Python before starting the IPC

### DIFF
--- a/inst/private/assert_have_python_and_sympy.m
+++ b/inst/private/assert_have_python_and_sympy.m
@@ -16,7 +16,7 @@
 %% License along with this software; see the file COPYING.
 %% If not, see <http://www.gnu.org/licenses/>.
 
-function assert_we_have_python(pyexec)
+function assert_have_python_and_sympy(pyexec)
 %private function
 
   [st, out] = system([pyexec ' -c "a = 42"']);
@@ -27,4 +27,22 @@ function assert_we_have_python(pyexec)
            '    Is Python installed?  Is your "path" configured correctly?'], ...
           pyexec)
   end
+
+
+  minsympyver = '0.7.6';
+
+  [st, out] = system([pyexec ' -c "import sympy; print(sympy.__version__)"']);
+
+  if (st ~= 0)
+    error('OctSymPy:nosympy', ...
+          'Python cannot import SymPy: have you installed SymPy?')
+  else
+    spver = strtrim(out);
+    if (compare_versions (spver, minsympyver, '<'))
+      error('OctSymPy:oldsympy', ...
+            'SymPy is installed but is too old (sympy-%s found, %s required)', ...
+            spver, minsympyver)
+    end
+  end
+
 end

--- a/inst/private/assert_we_have_python.m
+++ b/inst/private/assert_we_have_python.m
@@ -1,0 +1,30 @@
+%% Copyright (C) 2016 Colin B. Macdonald
+%%
+%% This file is part of OctSymPy.
+%%
+%% OctSymPy is free software; you can redistribute it and/or modify
+%% it under the terms of the GNU General Public License as published
+%% by the Free Software Foundation; either version 3 of the License,
+%% or (at your option) any later version.
+%%
+%% This software is distributed in the hope that it will be useful,
+%% but WITHOUT ANY WARRANTY; without even the implied warranty
+%% of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See
+%% the GNU General Public License for more details.
+%%
+%% You should have received a copy of the GNU General Public
+%% License along with this software; see the file COPYING.
+%% If not, see <http://www.gnu.org/licenses/>.
+
+function assert_we_have_python(pyexec)
+%private function
+
+  [st, out] = system([pyexec ' -c "a = 42"']);
+  if (st ~= 0)
+    error('OctSymPy:nopython', ...
+          ['Cannot run the Python executable "%s"\n' ...
+           '    Python and SymPy are needed for most Symbolic features.\n' ...
+           '    Is Python installed?  Is your "path" configured correctly?'], ...
+          pyexec)
+  end
+end

--- a/inst/private/python_ipc_popen2.m
+++ b/inst/private/python_ipc_popen2.m
@@ -75,7 +75,7 @@ function [A, info] = python_ipc_popen2(what, cmd, varargin)
       disp('Initializing communication with SymPy using a popen2() pipe.')
     end
     pyexec = sympref('python');
-    assert_we_have_python(pyexec)
+    assert_have_python_and_sympy(pyexec)
 
     if (ispc() && ~isunix())
       % Octave popen2 on Windows can't tolerate stderr output

--- a/inst/private/python_ipc_popen2.m
+++ b/inst/private/python_ipc_popen2.m
@@ -75,6 +75,8 @@ function [A, info] = python_ipc_popen2(what, cmd, varargin)
       disp('Initializing communication with SymPy using a popen2() pipe.')
     end
     pyexec = sympref('python');
+    assert_we_have_python(pyexec)
+
     if (ispc() && ~isunix())
       % Octave popen2 on Windows can't tolerate stderr output
       % https://savannah.gnu.org/bugs/?43036

--- a/inst/private/python_ipc_sysoneline.m
+++ b/inst/private/python_ipc_sysoneline.m
@@ -104,7 +104,7 @@ function [A, info] = python_ipc_sysoneline(what, cmd, mktmpfile, varargin)
 
   pyexec = sympref('python');
   if (first_time)
-    assert_we_have_python(pyexec)
+    assert_have_python_and_sympy(pyexec)
   end
 
   bigs = [headers s1 s2 s3];

--- a/inst/private/python_ipc_sysoneline.m
+++ b/inst/private/python_ipc_sysoneline.m
@@ -33,7 +33,7 @@
 
 function [A, info] = python_ipc_sysoneline(what, cmd, mktmpfile, varargin)
 
-  persistent show_msg
+  persistent first_time
 
   info = [];
 
@@ -49,14 +49,17 @@ function [A, info] = python_ipc_sysoneline(what, cmd, mktmpfile, varargin)
 
   verbose = ~sympref('quiet');
 
-  if (verbose && isempty(show_msg))
+  if (isempty(first_time))
+    first_time = true;
+  end
+
+  if (verbose && first_time)
     fprintf('OctSymPy v%s: this is free software without warranty, see source.\n', ...
             sympref('version'))
     disp('Using system()-based communication with Python [sysoneline].')
     disp('Warning: this will be *SLOW*.  Every round-trip involves executing a')
     disp('new Python process and many operations involve several round-trips.')
     disp('Warning: "sysoneline" will fail when using very long expressions.')
-    show_msg = true;
   end
 
   newl = sprintf('\n');
@@ -100,6 +103,9 @@ function [A, info] = python_ipc_sysoneline(what, cmd, mktmpfile, varargin)
   s3 = ['exec(\"' s '\");'];
 
   pyexec = sympref('python');
+  if (first_time)
+    assert_we_have_python(pyexec)
+  end
 
   bigs = [headers s1 s2 s3];
 
@@ -149,6 +155,9 @@ function [A, info] = python_ipc_sysoneline(what, cmd, mktmpfile, varargin)
   assert(length(ind) == 2)
   A = extractblock(out(ind(2):end));
 
+  if (first_time)
+    first_time = false;
+  end
 end
 
 

--- a/inst/private/python_ipc_system.m
+++ b/inst/private/python_ipc_system.m
@@ -81,7 +81,7 @@ function [A, info] = python_ipc_system(what, cmd, mktmpfile, varargin)
 
   pyexec = sympref('python');
   if (first_time)
-    assert_we_have_python(pyexec)
+    assert_have_python_and_sympy(pyexec)
   end
 
   %% FIXME: Issue #63: with new regexp code on Matlab

--- a/inst/private/python_ipc_system.m
+++ b/inst/private/python_ipc_system.m
@@ -33,7 +33,7 @@
 
 function [A, info] = python_ipc_system(what, cmd, mktmpfile, varargin)
 
-  persistent show_msg
+  persistent first_time
 
   info = [];
 
@@ -49,13 +49,16 @@ function [A, info] = python_ipc_system(what, cmd, mktmpfile, varargin)
 
   verbose = ~sympref('quiet');
 
-  if (verbose && isempty(show_msg))
+  if (isempty(first_time))
+    first_time = true;
+  end
+
+  if (verbose && first_time)
     fprintf('OctSymPy v%s: this is free software without warranty, see source.\n', ...
             sympref('version'))
     disp('You are using the slower system() communications with SymPy.')
     disp('Warning: this will be *SLOW*.  Every round-trip involves executing a')
     disp('new python process and many operations involve several round-trips.')
-    show_msg = true;
   end
 
   newl = sprintf('\n');
@@ -77,6 +80,9 @@ function [A, info] = python_ipc_system(what, cmd, mktmpfile, varargin)
   s = strjoin([s_in cmd s_out], newl);
 
   pyexec = sympref('python');
+  if (first_time)
+    assert_we_have_python(pyexec)
+  end
 
   %% FIXME: Issue #63: with new regexp code on Matlab
   % workaround:
@@ -136,4 +142,7 @@ function [A, info] = python_ipc_system(what, cmd, mktmpfile, varargin)
   assert(length(ind) == 2)
   A = extractblock(out(ind(2):end));
 
+  if (first_time)
+    first_time = false;
+  end
 end


### PR DESCRIPTION
Fixes #417.  For the system-based mechanism, we only do this once
to avoid overhead with each call.