### PR TITLE
Check for file existence before calling str2func

### DIFF
--- a/inst/@sym/function_handle.m
+++ b/inst/@sym/function_handle.m
@@ -134,12 +134,17 @@ function f = function_handle(varargin)
     fclose(fid);
     fprintf('Wrote file %s.\n', file_to_write);
     
-    fprintf('Checking for the function to exist... ');
+    %FIXME: Check upstream to rehash the files correctly once created
+    if(exist('OCTAVE_VERSION') && ispc())
+    fprintf('Due to an upstream bug in octave on windows, we have to wait for the file to be loaded.\n');
+    fprintf('See https://savannah.gnu.org/bugs/?31080 for more information...\n');
+    fprintf('Finding function %s... ', fcnname);
     while (exist(fcnname) == 0)
     end
-    fprintf('Found!\n');
-    f = str2func(fcnname);
+    fprintf('Found!\n\n');
+    end
     
+    f = str2func(fcnname);
 
   else % output function handle
 

--- a/inst/@sym/function_handle.m
+++ b/inst/@sym/function_handle.m
@@ -130,9 +130,16 @@ function f = function_handle(varargin)
     [fid,msg] = fopen(file_to_write, 'w');
     assert(fid > -1, msg)
     fprintf(fid, '%s', M.code)
+    fflush(fid);
     fclose(fid);
     fprintf('Wrote file %s.\n', file_to_write);
+    
+    fprintf('Checking for the function to exist... ');
+    while (exist(fcnname) == 0)
+    end
+    fprintf('Found!\n');
     f = str2func(fcnname);
+    
 
   else % output function handle
 

--- a/inst/@sym/function_handle.m
+++ b/inst/@sym/function_handle.m
@@ -130,16 +130,17 @@ function f = function_handle(varargin)
     [fid,msg] = fopen(file_to_write, 'w');
     assert(fid > -1, msg)
     fprintf(fid, '%s', M.code)
-    fflush(fid);
     fclose(fid);
     fprintf('Wrote file %s.\n', file_to_write);
     
-    %FIXME: Check upstream to rehash the files correctly once created
-    if(exist('OCTAVE_VERSION') && ispc())
-    fprintf('Due to an upstream bug in octave on windows, we have to wait for the file to be loaded.\n');
-    fprintf('See https://savannah.gnu.org/bugs/?31080 for more information...\n');
+    % FIXME: Check upstream to rehash the files correctly once created
+    % Due to an upstream bug in octave on windows, we have to wait for the file to be loaded.
+    % See https://savannah.gnu.org/bugs/?31080 for more information...\n
+    if(exist('OCTAVE_VERSION', 'builtin') && ispc())
     fprintf('Finding function %s... ', fcnname);
+    fflush(stdout);
     while (exist(fcnname) == 0)
+        rehash
     end
     fprintf('Found!\n\n');
     end


### PR DESCRIPTION
Fixes #431 

Although I don't think this is a nice solution, it is here just for temporary solution.
I added `fflush(fid)` but that doesn't seem to do the job. So, I had to use the `while`.

Probably we have to reload some sort of global cache for files in octave?