### PR TITLE
Use canonical test for Octave on OCTAVE_VERSION

### DIFF
--- a/inst/@sym/function_handle.m
+++ b/inst/@sym/function_handle.m
@@ -243,7 +243,7 @@ end
 %!test
 %! % output to disk
 %! fprintf('\n')
-%! if (exist ('octave_config_info', 'builtin'))
+%! if (exist ('OCTAVE_VERSION', 'builtin'))
 %!   temp_file = tempname('', 'oct_');
 %! else
 %!   temp_file = tempname();
@@ -263,7 +263,7 @@ end
 
 %!test
 %! % output to disk: also works with .m specified
-%! if (exist ('octave_config_info', 'builtin'))
+%! if (exist ('OCTAVE_VERSION', 'builtin'))
 %!   temp_file = [tempname('', 'oct_') '.m'];
 %! else
 %!   temp_file = [tempname() '.m'];
@@ -297,7 +297,7 @@ end
 %! H = [x y z];
 %! M = [x y; z 16];
 %! V = [x;y;z];
-%! if (exist ('octave_config_info', 'builtin'))
+%! if (exist ('OCTAVE_VERSION', 'builtin'))
 %!   temp_file = tempname('', 'oct_');
 %! else
 %!   temp_file = tempname();

--- a/inst/@sym/private/ustr_length.m
+++ b/inst/@sym/private/ustr_length.m
@@ -30,7 +30,7 @@ function n = ustr_length(str)
 %   sure of the relationship between the amount of (monospaced) space
 %   taken by a string and the results of this function.
 
-  if ~exist('octave_config_info', 'builtin')
+  if ~exist('OCTAVE_VERSION', 'builtin')
     n = length(str);
     return
   end

--- a/inst/@sym/sym.m
+++ b/inst/@sym/sym.m
@@ -573,7 +573,7 @@ end
 %! assert (isequal (a, a1))
 %! assert (isequal (a, a2))
 %! % Octave only, and eval to hide from Matlab parser
-%! if exist('octave_config_info', 'builtin')
+%! if exist('OCTAVE_VERSION', 'builtin')
 %!   eval( 'a3 = sym("Symbol(''a'')");' );
 %!   eval( 'a4 = sym("Symbol(\"a\")");' );
 %!   assert (isequal (a, a3))

--- a/inst/@symfun/symfun.m
+++ b/inst/@symfun/symfun.m
@@ -247,7 +247,7 @@ end
 %!test
 %! % Bug #41: Octave <= 3.8 parser fails without quotes around 2D fcn
 %! % (put inside eval to hide from 3.6 parser)
-%! if exist('octave_config_info', 'builtin')
+%! if exist('OCTAVE_VERSION', 'builtin')
 %!   if (compare_versions (OCTAVE_VERSION (), '4.0.0', '>='))
 %!     syms x y
 %!     eval('syms g(x,y)')

--- a/inst/private/do_highbyte_escapes.m
+++ b/inst/private/do_highbyte_escapes.m
@@ -56,7 +56,7 @@ function r = do_highbyte_escapes(s)
   end
   r = [r s(i:end)];
 
-  if (~ exist ('octave_config_info', 'builtin'))
+  if (~ exist ('OCTAVE_VERSION', 'builtin'))
     % matlab is not UTF-8 internally
     r = native2unicode(uint8(r));
   end

--- a/inst/private/my_print_usage.m
+++ b/inst/private/my_print_usage.m
@@ -31,7 +31,7 @@
 function print_usage ()
 
   % if we are on Octave
-  if (exist ('octave_config_info', 'builtin'))
+  if (exist ('OCTAVE_VERSION', 'builtin'))
     %evalin ('caller', 'print_usage ();' );
     %return
   end

--- a/inst/private/python_ipc_driver.m
+++ b/inst/private/python_ipc_driver.m
@@ -31,7 +31,7 @@ function [A, db] = python_ipc_driver(what, cmd, varargin)
   which_ipc = sympref('ipc');
 
   %% version check
-  if exist('octave_config_info', 'builtin')
+  if exist('OCTAVE_VERSION', 'builtin')
     if (compare_versions (OCTAVE_VERSION (), '3.6.4', '<'))
       fprintf(['\n********************************************************************\n' ...
                'Your Octave version is %s but Octsympy is currently untested on\n' ...


### PR DESCRIPTION
Test for existence of "OCTAVE_VERSION" instead of "octave_config_info",
recommended best practice by upstream, and the latter is deprecated in
Octave 4.1+.