### PR TITLE
Only use winwrapy.bat on Octave <= 4.0.2

### DIFF
--- a/inst/private/python_ipc_popen2.m
+++ b/inst/private/python_ipc_popen2.m
@@ -77,11 +77,9 @@ function [A, info] = python_ipc_popen2(what, cmd, varargin)
     pyexec = sympref('python');
     assert_have_python_and_sympy(pyexec)
 
-    if (ispc() && ~isunix())
-      % Octave popen2 on Windows can't tolerate stderr output
-      % https://savannah.gnu.org/bugs/?43036
+    if (ispc() && ~isunix() && compare_versions (OCTAVE_VERSION (), '4.0.2', '<='))
       if (verbose)
-        disp('Detected Windows: using "winwrapy.bat" to workaround Octave bug #43036')
+        disp('Using winwrapy.bat workaround for bug #43036 (Octave <= 4.0.2, on Windows)')
       end
       [fin, fout, pid] = popen2 ('winwrapy.bat', pyexec);
     else


### PR DESCRIPTION
Fixes #449.