### PR TITLE
[maint] Add PyTave to CI matrix

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,11 +7,11 @@ language: python
 matrix:
   include:
     - python: "2.7"
-      env: SYMPY_VER=1.0 OCT_PPA=yes PYTAVE=yes DOCTEST=yes COLUMNS=80
+      env: PYTAVE=yes SYMPY_VER=1.0 OCT_PPA=yes DOCTEST=yes COLUMNS=80
     - python: "2.7"
-      env: SYMPY_VER=1.0 OCT_PPA=yes PYTAVE=no DOCTEST=yes COLUMNS=80
+      env: PYTAVE=no  SYMPY_VER=1.0 OCT_PPA=yes DOCTEST=yes COLUMNS=80
     - python: "3.5"
-      env: SYMPY_VER=1.0 OCT_PPA=yes PYTAVE=no DOCTEST=yes COLUMNS=80
+      env: PYTAVE=no  SYMPY_VER=1.0 OCT_PPA=yes DOCTEST=yes COLUMNS=80
 
 # need octave devel pkgs for doctest (has compiled code as of July 2015)
 install:

--- a/.travis.yml
+++ b/.travis.yml
@@ -27,8 +27,12 @@ install:
   - if [ "x$PYTAVE" = "xyes" ]; then
         hg clone https://bitbucket.org/mtmiller/pytave;
         cd pytave;
+	pwd;
+	aclocal -I m4;
+	autoconf;
         ./configure;
         make;
+	cd ..;
     fi
 
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -25,10 +25,10 @@ install:
         octave -W --no-gui --eval "pkg install -forge doctest";
     fi
   - if [ "x$PYTAVE" = "xyes" ]; then
-        hg clone https://bitbucket.org/mtmiller/pytave
-        cd pytave
-        ./configure
-        make
+        hg clone https://bitbucket.org/mtmiller/pytave;
+        cd pytave;
+        ./configure;
+        make;
     fi
 
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -27,12 +27,12 @@ install:
   - if [ "x$PYTAVE" = "xyes" ]; then
         hg clone https://bitbucket.org/mtmiller/pytave;
         cd pytave;
-	pwd;
-	aclocal -I m4;
-	autoconf;
+        pwd;
+        aclocal -I m4;
+        autoconf;
         ./configure;
         make;
-	cd ..;
+        cd ..;
     fi
 
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,9 +7,11 @@ language: python
 matrix:
   include:
     - python: "2.7"
-      env: SYMPY_VER=1.0 OCT_PPA=yes DOCTEST=yes COLUMNS=80
+      env: SYMPY_VER=1.0 OCT_PPA=yes PYTAVE=yes DOCTEST=yes COLUMNS=80
+    - python: "2.7"
+      env: SYMPY_VER=1.0 OCT_PPA=yes PYTAVE=no DOCTEST=yes COLUMNS=80
     - python: "3.5"
-      env: SYMPY_VER=1.0 OCT_PPA=yes DOCTEST=yes COLUMNS=80
+      env: SYMPY_VER=1.0 OCT_PPA=yes PYTAVE=no DOCTEST=yes COLUMNS=80
 
 # need octave devel pkgs for doctest (has compiled code as of July 2015)
 install:
@@ -22,6 +24,13 @@ install:
   - if [ "x$DOCTEST" = "xyes" ]; then
         octave -W --no-gui --eval "pkg install -forge doctest";
     fi
+  - if [ "x$PYTAVE" = "xyes" ]; then
+        hg clone https://bitbucket.org/mtmiller/pytave
+        cd pytave
+        ./configure
+        make
+    fi
+
 
 # all commands here must have exit code 0 for the build to be called "passing"
 # debugging: octave -W --no-gui --eval "syms x; A = [x sin(x) x^3]; A; exit(0)"


### PR DESCRIPTION
This doesn't actually work yet, but first steps to get it downloaded...
Idea is that Symbolic will automatically use PyTave if available.

- [ ] the test should fail if pytave build fails