### PR TITLE
[maint] CI needs some GPG key when using updated Octave PPA

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,6 +14,7 @@ matrix:
 # need octave devel pkgs for doctest (has compiled code as of July 2015)
 install:
   - if [ "x$OCT_PPA" = "xyes" ]; then
+        sudo apt-key adv --keyserver keyserver.ubuntu.com --recv-keys 1397BC53640DB551;
         sudo apt-add-repository -y ppa:octave/stable;
     fi
   - sudo apt-get update -qq -y;


### PR DESCRIPTION
I've not looked into exactly what has changed and why but I assume
its related to Octave 4.0.2 going into the "octave/stable" PPA.
(Blindly copying commands about GPG off the internet: you'd think I'd
know better!)
