### PR TITLE
Tests for escaped-strings were wrong

### DIFF
--- a/inst/private/python_copy_vars_to.m
+++ b/inst/private/python_copy_vars_to.m
@@ -56,6 +56,16 @@ function a = do_list(indent, in, varlist)
       c=c+1; a{c} = sprintf('%s%s.append(%s)', sp, in, sprintf(char(x)));
 
     elseif (ischar(x))
+      if (exist ('OCTAVE_VERSION', 'builtin'))
+        x = undo_string_escapes(x);
+      else
+        % roughly same as the above on Matlab?
+        x = strrep(x, '\', '\\');
+        x = strrep(x, '"', '\"');
+        for cc = {'\n' '\r' '\t' '\b' '\f'}
+          x = strrep(x, sprintf(cc{:}), cc{:});
+        end
+      end
       c=c+1; a{c} = [sp in '.append("' x '")'];
       % or do we want a printf() around the string?
       %c=c+1; a{c} = sprintf('%s%s.append("%s")', sp, in, x);

--- a/inst/python_cmd.m
+++ b/inst/python_cmd.m
@@ -347,20 +347,20 @@ end
 %! s2 = python_cmd (cmd);
 %! assert (strcmp (s1, s2))
 
-%%!test
-%%! % unicode passthru: FIXME: how to get unicode back to Python?
-%%! s1 = '我爱你'
-%%! cmd = 'return (_ins[0],)';
-%%! s2 = python_cmd (cmd, s1)
-%%! assert (strcmp (s1, s2))
+%!xtest
+%! % unicode passthru
+%! s = '我爱你';
+%! s2 = python_cmd ('return _ins', s);
+%! assert (strcmp (s, s2))
+%! s = '我爱你<>\&//\#%% %\我';
+%! s2 = python_cmd ('return _ins', s);
+%! assert (strcmp (s, s2))
 
-%%!test
-%%! % unicode w/ slashes, escapes, etc  FIXME
-%%! s1 = '我爱你<>\\&//\\#%% %\\我'
-%%! s3 = '我爱你<>\&//\#%% %\我'
-%%! cmd = 'return _ins[0]';
-%%! s2 = python_cmd (cmd, s1)
-%%! assert (strcmp (s2, s3))
+%!xtest
+%! % unicode w/ slashes, escapes
+%! s = '我<>\&//\#%% %\我';
+%! s2 = python_cmd ('return "我<>\\&//\\#%% %\\我"');
+%! assert (strcmp (s, s2))
 
 %!test
 %! % list, tuple

--- a/inst/python_cmd.m
+++ b/inst/python_cmd.m
@@ -218,28 +218,24 @@ end
 %! assert (strcmp(y, 'Octave'))
 
 %!test
-%! % string with newlines
-%! % FIXME: escaped in input should still be escaped in output
+%! % string with escaped newlines, comes back as escaped newlines
 %! x = 'a string\nbroke off\nmy guitar\n';
-%! x2 = sprintf(x);
 %! y = python_cmd ('return _ins', x);
-%! x3 = strrep(x2, sprintf('\n'), sprintf('\r\n'));  % windows
-%! assert (strcmp(y, x2) || strcmp(y, x3))
+%! assert (strcmp(y, x))
 
 %!test
-%! % bug: cmd string with newlines, works with cell
-%! % FIXME: no addition escaping for this one
+%! % string with actual newlines, comes back as actual newlines
+%! x = sprintf('a string\nbroke off\nmy guitar\n');
+%! y = python_cmd ('return _ins', x);
+%! y2 = strrep(y, sprintf('\n'), sprintf('\r\n'));  % windows
+%! assert (strcmp(x, y) || strcmp(x, y2))
+
+%!test
+%! % cmd string with newlines, works with cell
 %! y = python_cmd ('return "string\nbroke",');
 %! y2 = sprintf('string\nbroke');
 %! y3 = strrep(y2, sprintf('\n'), sprintf('\r\n'));  % windows
 %! assert (strcmp(y, y2) || strcmp(y, y3))
-
-%%!test
-%%! % FIXME: newlines: should be escaped for import?
-%%! x = 'a string\nbroke off\nmy guitar\n';
-%%! x2 = sprintf(x);
-%%! y = python_cmd ('return _ins', x2);
-%%! assert (strcmp(y, x2))
 
 %!test
 %! % string with XML escapes
@@ -252,16 +248,12 @@ end
 
 %!test
 %! % strings with double quotes
-%! % maybe its sensible to need to escape double-quotes to send to python?
-%! % FIXME: or we could escape ", \, \n automatically?
 %! x = 'a\"b\"c';
-%! expy = 'a"b"c';
 %! y = python_cmd ('return _ins', x);
-%! assert (strcmp(y, expy))
+%! assert (strcmp(y, x))
 %! x = '\"';
-%! expy = '"';
 %! y = python_cmd ('return _ins', x);
-%! assert (strcmp(y, expy))
+%! assert (strcmp(y, x))
 
 %!test
 %! % cmd has double quotes, these must be escaped by user
@@ -279,10 +271,14 @@ end
 %!test
 %! % strings with quotes
 %! x = '\"a''b\"c''\"d';
-%! y1 = '"a''b"c''"d';
-%! cmd = 's = _ins[0]; return s,';
-%! y2 = python_cmd (cmd, x);
-%! assert (strcmp(y1, y2))
+%! y = python_cmd ('return _ins[0]', x);
+%! assert (strcmp(y, x))
+
+%!test
+%! % strings with quotes
+%! expy = '"a''b"c''"d';
+%! y = python_cmd ('s = "\"a''b\"c''\"d"; return s');
+%! assert (strcmp(y, expy))
 
 %!test
 %! % strings with printf escapes
@@ -303,10 +299,16 @@ end
 %! assert (strcmp(y, expy))
 
 %!test
-%! % slashes: FIXME: auto escape backslashes
+%! % slashes
 %! x = '/\\ // \\\\ \\/\\/\\';
 %! z = '/\ // \\ \/\/\';
 %! y = python_cmd ('return _ins', x);
+%! assert (strcmp(y, x))
+
+%!test
+%! % slashes
+%! z = '/\ // \\ \/\/\';
+%! y = python_cmd ('return "/\\ // \\\\ \\/\\/\\"');
 %! assert (strcmp(y, z))
 
 %!test


### PR DESCRIPTION
The string we have in Octave should be passed into to Python without
changing it.  This means we may have to do some escaping for the string
to get through the IPC mechanism: with the current ones, this means
calling "undo_string_escapes".  Invent a quick-n-dirty implementation
of said for matlab.

Fixes #487.