### PR TITLE
fix python_cmd - return without ,

### DIFF
--- a/inst/python_cmd.m
+++ b/inst/python_cmd.m
@@ -176,6 +176,10 @@ function varargout = python_cmd(cmd, varargin)
     error(sprintf('Python exception: %s\n    occurred %s', A{3}, A{2}));
   end
 
+  if (~iscell(A{1}) && (length(A) ~= 1))
+    A={A};
+  end
+
   M = length(A);
   varargout = cell(1,M);
   for i=1:M


### PR DESCRIPTION
Hi all, well i found this little problem, when we send some return to can set the varargout the A should be in the form:

```
A = 
{  
    [1,1] =
    {
        (sym) 1
.....
    }
}
```

but when we send a return without "," like 'return A' and A its a list octave interpret it as
```
A =
{
    (sym) 1
    ....
}
```

causing varargin only takes the first value of the list.

Cya.