### PR TITLE
find all assumptions for sympy versions (ver2) - fully-automatic

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -1,6 +1,8 @@
 octsympy 2.5.0-dev
 ==================
 
+  * The full set of assumptions implemented by Sympy can now be used.
+
   * New symbolic commands:
 
           acosd         cosd

--- a/inst/assumptions.m
+++ b/inst/assumptions.m
@@ -66,7 +66,7 @@
 %% @group
 %% A = assumptions('possible');
 %% sprintf('%s ', A@{:@})
-%%   @result{} ans = real positive negative integer even odd rational finite
+%%   @result{} ans = ...
 %% @end group
 %% @end example
 %%

--- a/inst/private/valid_sym_assumptions.m
+++ b/inst/private/valid_sym_assumptions.m
@@ -24,23 +24,16 @@
 
 %% Source: http://docs.sympy.org/dev/modules/core.html
 
+%% FIXME: Maybe in the future remove this file and replace with something else.
+
 function L = valid_sym_assumptions()
 
   persistent List
 
   if (isempty(List))
 
-    %%FIXME: After a while update the list.
-    cmd = {'r = []'
-           'L = ["commutative", "complex", "imaginary", "real", "integer", "odd", "even", "prime", "composite", "zero", "nonzero", "rational", "algebraic", "trascendental", "irrational", "finite", "infinite", "negative", "nonnegative", "positive", "nonpositive", "hermitian", "antihermitian"]'
-           'x = Symbol("x")'
-           'for i in range(len(L)):'
-           '    try:'
-           '        q = eval("x.is_" + L[i])'
-           '        r = r + [L[i]]'
-           '    except:'
-           '        pass'
-           'return r,'};
+    cmd = {'from sympy.core.assumptions import _assume_defined as L'
+           'return list(L),'};
     List = python_cmd(cmd);
 
   end

--- a/inst/private/valid_sym_assumptions.m
+++ b/inst/private/valid_sym_assumptions.m
@@ -22,10 +22,29 @@
 %%
 %% @end defun
 
+%% Source: http://docs.sympy.org/dev/modules/core.html
+
 function L = valid_sym_assumptions()
 
-  L = {'real', 'positive', 'negative', 'integer', 'even', 'odd', ...
-       'rational', 'finite'};
+  persistent List
+
+  if (isempty(List))
+
+    %%FIXME: After a while update the list.
+    cmd = {'r = []'
+           'L = ["commutative", "complex", "imaginary", "real", "integer", "odd", "even", "prime", "composite", "zero", "nonzero", "rational", "algebraic", "trascendental", "irrational", "finite", "infinite", "negative", "nonnegative", "positive", "nonpositive", "hermitian", "antihermitian"]'
+           'x = Symbol("x")'
+           'for i in range(len(L)):'
+           '    try:'
+           '        q = eval("x.is_" + L[i])'
+           '        r = r + [L[i]]'
+           '    except:'
+           '        pass'
+           'return r,'};
+    List = python_cmd(cmd);
+
+  end
+
+  L = List;
 
 end
-


### PR DESCRIPTION
Hi again, here i'm dealing with this little problem, basically octsympy only have specific assumptions to can use independent of the sympy version, and checking the docs of sympy it doesn't says what assumptions are supported for version, only in the dev:http://docs.sympy.org/dev/modules/core.html

So this code use the dev assumptions and detect which are available in the actual version of Sympy, actually i can't found a way to completely auto-detect (that's why ver1) it but if we update this list when Sympy bring new versions should works fine.

Edited:

Now is fully automated!

Cya.