### PR TITLE
disable symfuns with the same names of python funcs env.

### DIFF
--- a/inst/private/python_header.py
+++ b/inst/private/python_header.py
@@ -44,6 +44,7 @@ try:
     import codecs
     import xml.etree.ElementTree as ET
     from distutils.version import LooseVersion
+    import re
 except:
     echo_exception_stdout("in python_header import block")
     raise


### PR DESCRIPTION
Fixes https://github.com/cbm755/octsympy/issues/290

To know details about this check the same issue.

Basically, disable the symfuns with a equal name of a python function.

Cya.
