### PR TITLE
try block to check sym creation

### DIFF
--- a/inst/@sym/sym.m
+++ b/inst/@sym/sym.m
@@ -238,9 +238,9 @@ function s = sym(x, varargin)
 
   elseif (islogical (x)  &&  isscalar(x)  &&  nargin==1)
     if (x)
-      cmd = 'z = sp.S.true';
+      cmd = {'z = sp.S.true'};
     else
-      cmd = 'z = sp.S.false';
+      cmd = {'z = sp.S.false'};
     end
 
   elseif (nargin == 2 && ischar(varargin{1}) && strcmp(varargin{1},'clear'))
@@ -329,16 +329,20 @@ function s = sym(x, varargin)
         warning('possibly unintended decimal point in constructor string');
       end
       % x is raw sympy, could have various quotes in it
-      cmd = sprintf('z = sympy.S("%s")', strrep(x, '"', '\"'));
+      x = strrep(x, '"', '\"');
+      cmd = try_sym(x, sprintf('z = sympy.S("%s")', x));
 
     else % useSymbolNotS
       if (isempty(asm))
-        cmd = sprintf('z = sympy.Symbol("%s")', x);
+        cmd = try_sym(x, sprintf('z = sympy.Symbol("%s")', x));
 
       elseif (isscalar(asm) && isscalar(asm{1}) && isstruct(asm{1}))
         % we have an assumptions dict
-        cmd = sprintf('return sympy.Symbol("%s", **_ins[0]),', x);
-        s = python_cmd (cmd, asm{1});
+        cmd = try_sym(x, sprintf('return (sympy.Symbol("%s", **_ins[0]), True)', x));
+        [s, u] = python_cmd (cmd, asm{1});
+        if ~u
+          error(['Error making the symfun "' s '", you wrote correctly the symbol?, or its a Python function.']);
+        end
         return
 
       elseif (iscell(asm))
@@ -348,8 +352,8 @@ function s = sym(x, varargin)
           assert(ismember(asm{n}, valid_asm), ...
                  'sym: that assumption is not supported')
         end
-        cmd = ['z = sympy.Symbol("' x '"' ...
-               sprintf(', %s=True', asm{:}) ')'];
+        cmd = {['z = sympy.Symbol("' x '"' sprintf(', %s=True', asm{:}), ')']};
+        cmd = try_sym(x, cmd);
       else
         error('sym: invalid extra input, perhaps invalid assumptions?');
       end
@@ -362,7 +366,28 @@ function s = sym(x, varargin)
     error('conversion to symbolic with those arguments not (yet) supported');
   end
 
-  s = python_cmd ({cmd 'return z,'});
+  [s, u] = python_cmd ([cmd; 'return (z, True)']);
+  if ~u
+    error(['Error making the symfun "' s '", you wrote correctly the symbol?, or its a Python function.']);
+  end
+
+end
+
+
+function a = try_sym(x, y)
+
+  if ~iscell(y)
+    y = {y};
+  end
+
+  assert( isequal( length(y), 1), 'try_sym only works with a 1 line input.')
+
+  cmd = { 'try:'
+        [ '    ' y{:}]
+          'except:'
+          '    return (x, False)' };
+
+  a = [sprintf('x = "%s"', x); cmd];
 
 end
 
@@ -693,3 +718,7 @@ end
 %! else
 %!   delete([myfile '.mat'])
 %! end
+
+%!error
+%! %% Bad python function.
+%! sym('FF(w)');


### PR DESCRIPTION
Fixes https://github.com/cbm755/octsympy/issues/290

Hi again, well thinking the last pr complicate things with the char command, so instead of disable the env functions use a try block to send the error, this is more... experimental?, or try to keep the same flexibility of the actual code, but this keep a similar problem making symbols:

```
>> sym('Eq(t)')
ans = (sym) t = 0
```

(for a normal user this is weird)
at least this is a step to handle this.
maybe send a warning when we use python code from the sym function?

Choose your preferred way to fix this :D 

Thx. Cya.
