### PR TITLE
rename xrange to range

### DIFF
--- a/inst/@sym/taylor.m
+++ b/inst/@sym/taylor.m
@@ -135,15 +135,15 @@ function s = taylor(f, varargin)
     cmd = {'(f, x, a, n) = _ins'
            'dic = dict(zip(x, a))'
            'xa = list(x)'
-           'for i in xrange(len(x)):'
+           'for i in range(len(x)):'
            '    xa[i] = x[i]-a[i]'
            'expn = f.subs(dic)  # first constant term'
-           'for i in xrange(1,n):'
+           'for i in range(1,n):'
            '    tmp = S(0)'
            '    d = list(itertools.product(x, repeat=i))'
            '    for j in d:'
            '        tmp2 = S(1)'
-           '        for p in xrange(len(x)):'
+           '        for p in range(len(x)):'
            '            tmp2 = tmp2*xa[p]**j.count(x[p])'
            '        tmp = tmp + f.diff(*j).subs(dic)*tmp2' %%FIXME: In this case we should use a cache system to avoid
            '    expn = expn + tmp / factorial(i)'          %%       diff in all vars every time (more ram, less time).


### PR DESCRIPTION
xrange was removed in Python 3, and in the actual Python 2.7 supports xrange format in range.