### PR TITLE
Refactor of Solve, and fix a test

### DIFF
--- a/inst/@sym/solve.m
+++ b/inst/@sym/solve.m
@@ -31,9 +31,9 @@
 %% @example
 %% @group
 %% syms x
-%% solve(x == 2*x + 6, x)
+%% solve (x == 2*x + 6, x)
 %%   @result{} ans = (sym) -6
-%% solve(x^2 + 6 == 5*x, x)
+%% solve (x^2 + 6 == 5*x, x)
 %%   @result{} ans = (sym 2×1 matrix)
 %%       ⎡2⎤
 %%       ⎢ ⎥
@@ -73,7 +73,7 @@
 %% Alternatively:
 %% @example
 %% @group
-%% [X, Y] = solve(x^2 == 4, x + y == 1, x, y)
+%% [X, Y] = solve (x^2 == 4, x + y == 1, x, y)
 %%   @result{} X = (sym 2×1 matrix)
 %%       ⎡-2⎤
 %%       ⎢  ⎥
@@ -89,12 +89,11 @@
 %% inequalities and equations.  For example:
 %% @example
 %% @group
-%% solve(x^2 == 4, x > 0)
+%% solve (x^2 == 4, x > 0)
 %%   @result{} ans = (sym) x = 2
 %% @end group
-%%
 %% @group
-%% solve(x^2 - 1 > 0, x < 10)
+%% solve (x^2 - 1 > 0, x < 10)
 %%   @result{} ans = (sym) (-∞ < x ∧ x < -1) ∨ (1 < x ∧ x < 10)
 %% @end group
 %% @end example
@@ -105,19 +104,22 @@
 
 function varargout = solve(varargin)
 
-  varargin = sym(varargin);
+  varargin = sym (varargin);
+
+  %% base use {extra} section to add specific options to solve
+  %% if you don't need it replace it with an empty string
+  base = { 'eqs = list(); symbols = list()'
+           'for arg in _ins:'
+           '    if arg.is_Relational:'
+           '        eqs.append(arg)'
+           '    else:'
+           '        symbols.append(arg)'
+           'd = sp.solve(eqs, *symbols{extra})'
+           'if not isinstance(d, (list, tuple)):'  % https://github.com/sympy/sympy/issues/11661
+           '    return d,' };
 
   if (nargout == 0 || nargout == 1)
-    cmd = { 'eqs = list(); symbols = list()'
-            'for arg in _ins:'
-            '    if arg.is_Relational:'
-            '        eqs.append(arg)'
-            '    else:'
-            '        symbols.append(arg)'
-            'd = sp.solve(eqs, *symbols, dict=True)'
-            'if not isinstance(d, (list, tuple)):'  % https://github.com/sympy/sympy/issues/11661
-            '    return d,'
-            'if len(d) >= 1 and len(d[0].keys()) == 1:'  % one variable...
+    cmd = { 'if len(d) >= 1 and len(d[0].keys()) == 1:'  % one variable...
             '    if len(d) == 1:'  % one variable, single solution
             '        return d[0].popitem()[1],'
             '    else:'  % one variable, multiple solutions
@@ -126,33 +128,22 @@ function varargout = solve(varargin)
             '    d = d[0]'
             'return d,' };
 
-    out = python_cmd (cmd, varargin{:});
+    out = python_cmd ([strrep(base, '{extra}', ', dict=True'); cmd], varargin{:});
 
     varargout = {out};
 
   else  % multiple outputs
-    cmd = { 'eqs = list(); symbols = list()'
-            'for arg in _ins:'
-            '    if arg.is_Relational:'
-            '        eqs.append(arg)'
-            '    else:'
-            '        symbols.append(arg)'
-            'd = sp.solve(eqs, *symbols, set=True)'
-            'if not isinstance(d, (list, tuple)):'  % https://github.com/sympy/sympy/issues/11661
-            '    return d,'
-            '(vars, solns) = d'
+    cmd = { '(vars, solns) = d'
             'q = []'
             'for (i, var) in enumerate(vars):'
             '    q.append(sp.Matrix([t[i] for t in solns]))'
             'return q,' };
 
-    out = python_cmd (cmd, varargin{:});
+    out = python_cmd ([strrep(base, '{extra}', ', set=True'); cmd], varargin{:});
+
+    assert (isequal (nargout, length (out)), ['This system have ' num2str(length (out)) ' vars solution, please set correct numbers of outputs.']);
 
     varargout = out;
-
-    if (length(out) ~= nargout)
-      warning('solve: number of outputs did not match solution vars');
-    end
 
   end
 
@@ -162,48 +153,48 @@ end
 %!test
 %! % Simple, single variable, single solution
 %! syms x
-%! d = solve(10*x == 50);
+%! d = solve (10*x == 50);
 %! assert (isequal (d, 5))
 
 %!test
 %! % Single variable, multiple solutions
 %! syms x
-%! d = solve(x^2 == 4);
-%! assert (length(d) == 2);
+%! d = solve (x^2 == 4);
+%! assert (length (d) == 2);
 %! assert (isequal (d, [2; -2]) || isequal (d, [-2; 2]))
 
 %!shared x,y,e
 %! syms x y
 %! e = 10*x == 20*y;
 %!test
-%! d = solve(e, x);
+%! d = solve (e, x);
 %! assert (isequal (d, 2*y))
 %!test
-%! d = solve(e, y);
+%! d = solve (e, y);
 %! assert (isequal (d, x/2))
 %!test
-%! d = solve(e);
+%! d = solve (e);
 %! assert (isequal (d, 2*y))
 
 %!test
 %! % Solve for an expression 2*x instead of a variable.  Note only very
 %! % simple examples will work, see "?solve" in SymPy, hence this is no
 %! % longer documented in the help text.
-%! d = solve(e, 2*x);
+%! d = solve (e, 2*x);
 %! assert (isequal (d, 4*y))
 
 %!test
-%! d = solve(2*x - 3*y == 0, x + y == 1);
-%! assert (isequal (d.x, sym(3)/5) && isequal(d.y, sym(2)/5))
+%! d = solve (2*x - 3*y == 0, x + y == 1);
+%! assert (isequal (d.x, sym (3)/5) && isequal (d.y, sym (2)/5))
 
 %!test
-%! d = solve(2*x-3*y==0,x+y==1,x,y);
-%! assert (isequal (d.x, sym(3)/5) && isequal(d.y, sym(2)/5))
+%! d = solve(2*x - 3*y == 0,x + y == 1,x,y);
+%! assert (isequal (d.x, sym (3)/5) && isequal (d.y, sym (2)/5))
 
 %!test
 %! % Multiple solutions, multiple variables
-%! d = solve(x^2 == 4, x + y == 1);
-%! assert (length(d) == 2);
+%! d = solve (x^2 == 4, x + y == 1);
+%! assert (length (d) == 2);
 %! % FIXME: SMT has d.x gives vector and d.y giving vector, what is
 %! % more intuitive?
 %! for i = 1:2
@@ -214,39 +205,43 @@ end
 %!test
 %! % No solutions
 %! syms x y z
-%! d = solve(x == y, z);
+%! d = solve (x == y, z);
 %! assert (isempty (d));
 
 %!test
 %! % Multiple outputs with single solution
 %! syms x y
-%! [X, Y] = solve(2*x + y == 5, x + y == 3);
+%! [X, Y] = solve (2*x + y == 5, x + y == 3);
 %! assert (isequal (X, 2))
 %! assert (isequal (Y, 1))
 
 %!test
 %! % Multiple outputs with multiple solns
 %! syms x y
-%! [X, Y] = solve(x*x == 4, x == 2*y);
+%! [X, Y] = solve (x*x == 4, x == 2*y);
 %! assert (isequal (X, [2; -2]))
 %! assert (isequal (Y, [1; -1]))
 
 %!test
 %! % Multiple outputs with multiple solns, specify vars
 %! syms x y
-%! [X, Y] = solve(x*x == 4, x == 2*y, x, y);
+%! [X, Y] = solve (x*x == 4, x == 2*y, x, y);
 %! assert (isequal (X, [2; -2]))
 %! assert (isequal (Y, [1; -1]))
 
 %!test
 %! syms x
-%! a = solve(2*x >= 10, 10*x <= 50);
-%! assert (isequal( a, x==sym(5)))
+%! a = solve (2*x >= 10, 10*x <= 50);
+%! assert (isequal (a, x == sym (5)))
+
+%!error
+%! syms x
+%! [a b] = solve (x^2 + x == 0)
 
 %!error
 %! syms a b
-%! solve(a==b, 1==1)
+%! solve (a == b, 1 == 1)
 
 %!error
 %! syms a b
-%! solve(a==b, 1==2)
+%! solve (a == b, 1 == 2)


### PR DESCRIPTION
Hi, you know, the continuation of the other pr, idea?, compact solve and pass this test:

```
%!test
%! syms x
%! [a b] = solve(x^2+x == 0)
```

i think this should be:

```
%!error
%! syms x
%! [a b] = solve(x^2+x == 0)
```

and should be handled for solve instead of octave

Thx.Cya.
