### PR TITLE
little fixes for Sets - SolveSet and Display

### DIFF
--- a/inst/@sym/display.m
+++ b/inst/@sym/display.m
@@ -136,11 +136,13 @@ function display(x)
   s = [s1 s2];
   n = ustr_length (s);
   %fputs (1, s);  % only in octave, not matlab
-  disp (s)
+
   if (display_snippet)
     % again, fputs safer, but not in matlab
-    fprintf (snippet_of_sympy (x, 7, term_width - n, unicode_dec))
+    s = [s snippet_of_sympy(x, 7, term_width - n, unicode_dec)];
   end
+
+  disp (s)
 
   if (toobig)
     if (loose), fprintf ('\n'); end

--- a/inst/@sym/display.m
+++ b/inst/@sym/display.m
@@ -135,10 +135,8 @@ function display(x)
   end
   s = [s1 s2];
   n = ustr_length (s);
-  %fputs (1, s);  % only in octave, not matlab
 
   if (display_snippet)
-    % again, fputs safer, but not in matlab
     s = [s snippet_of_sympy(x, 7, term_width - n, unicode_dec)];
   end
 

--- a/inst/@sym/display.m
+++ b/inst/@sym/display.m
@@ -136,12 +136,11 @@ function display(x)
   s = [s1 s2];
   n = ustr_length (s);
   %fputs (1, s);  % only in octave, not matlab
-  fprintf (s)
+  disp (s)
   if (display_snippet)
     % again, fputs safer, but not in matlab
     fprintf (snippet_of_sympy (x, 7, term_width - n, unicode_dec))
   end
-  fprintf ('\n');
 
   if (toobig)
     if (loose), fprintf ('\n'); end

--- a/inst/private/python_header.py
+++ b/inst/private/python_header.py
@@ -28,6 +28,7 @@ try:
     from sympy import __version__ as spver
     # need this to reactivate from srepr
     from sympy import *
+    from sympy.sets.fancysets import *
     import sympy.printing
     from sympy.logic.boolalg import Boolean, BooleanFunction
     from sympy.core.relational import Relational

--- a/inst/private/python_header.py
+++ b/inst/private/python_header.py
@@ -29,6 +29,7 @@ try:
     # need this to reactivate from srepr
     from sympy import *
     from sympy.sets.fancysets import *
+    from sympy.sets.sets import *
     import sympy.printing
     from sympy.logic.boolalg import Boolean, BooleanFunction
     from sympy.core.relational import Relational

--- a/inst/private/python_header.py
+++ b/inst/private/python_header.py
@@ -28,8 +28,6 @@ try:
     from sympy import __version__ as spver
     # need this to reactivate from srepr
     from sympy import *
-    from sympy.sets.fancysets import *
-    from sympy.sets.sets import *
     import sympy.printing
     from sympy.logic.boolalg import Boolean, BooleanFunction
     from sympy.core.relational import Relational
@@ -39,6 +37,9 @@ try:
     from sympy.matrices.expressions.matexpr import MatrixElement
     # for hypergeometric
     from sympy.functions.special.hyper import TupleArg
+    # for sets
+    from sympy.sets.fancysets import *
+    from sympy.sets.sets import *
     from sympy.utilities.iterables import uniq
     import copy
     import binascii

--- a/inst/private/python_ipc_native.m
+++ b/inst/private/python_ipc_native.m
@@ -65,8 +65,6 @@ function [A, info] = python_ipc_native(what, cmd, varargin)
                     'import sympy as sp'
                     'from sympy import __version__ as spver'
                     'from sympy import *'
-                    'from sympy.sets.fancysets import *'
-                    'from sympy.sets.sets import *'
                     'from sympy.logic.boolalg import Boolean, BooleanFunction'
                     'from sympy.core.relational import Relational'
                     '# temporary? for piecewise support'
@@ -75,6 +73,9 @@ function [A, info] = python_ipc_native(what, cmd, varargin)
                     'from sympy.matrices.expressions.matexpr import MatrixElement'
                     '# for hypergeometric'
                     'from sympy.functions.special.hyper import TupleArg'
+                    '# for sets
+                    'from sympy.sets.fancysets import *'
+                    'from sympy.sets.sets import *'
                     'from sympy.utilities.iterables import uniq'
                     'import copy'
                     'import struct'

--- a/inst/private/python_ipc_native.m
+++ b/inst/private/python_ipc_native.m
@@ -65,6 +65,8 @@ function [A, info] = python_ipc_native(what, cmd, varargin)
                     'import sympy as sp'
                     'from sympy import __version__ as spver'
                     'from sympy import *'
+                    'from sympy.sets.fancysets import *'
+                    'from sympy.sets.sets import *'
                     'from sympy.logic.boolalg import Boolean, BooleanFunction'
                     'from sympy.core.relational import Relational'
                     '# temporary? for piecewise support'

--- a/inst/private/python_ipc_pytave.m
+++ b/inst/private/python_ipc_pytave.m
@@ -65,6 +65,7 @@ function [A, info] = python_ipc_pytave(what, cmd, varargin)
                     'import sympy as sp'
                     'from sympy import __version__ as spver'
                     'from sympy import *'
+                    'from sympy.sets.fancysets import *'
                     'from sympy.logic.boolalg import Boolean, BooleanFunction'
                     'from sympy.core.relational import Relational'
                     '# temporary? for piecewise support'

--- a/inst/private/python_ipc_pytave.m
+++ b/inst/private/python_ipc_pytave.m
@@ -65,8 +65,6 @@ function [A, info] = python_ipc_pytave(what, cmd, varargin)
                     'import sympy as sp'
                     'from sympy import __version__ as spver'
                     'from sympy import *'
-                    'from sympy.sets.fancysets import *'
-                    'from sympy.sets.sets import *'
                     'from sympy.logic.boolalg import Boolean, BooleanFunction'
                     'from sympy.core.relational import Relational'
                     '# temporary? for piecewise support'

--- a/inst/private/python_ipc_pytave.m
+++ b/inst/private/python_ipc_pytave.m
@@ -66,6 +66,7 @@ function [A, info] = python_ipc_pytave(what, cmd, varargin)
                     'from sympy import __version__ as spver'
                     'from sympy import *'
                     'from sympy.sets.fancysets import *'
+                    'from sympy.sets.sets import *'
                     'from sympy.logic.boolalg import Boolean, BooleanFunction'
                     'from sympy.core.relational import Relational'
                     '# temporary? for piecewise support'


### PR DESCRIPTION
Hi, this is a fix to can work properly with this, i don't report this problems but anyway here are the fixes:

first for Display, `fprintf` don't support the backslash char and send errors:

```
octave:3> python_cmd('return S.UniversalSet - S.Reals')
warning: number of outputs don't match, was this intentional?
warning: called from
    python_cmd at line 188 column 5
warning: unrecognized escape sequence '\ ' -- converting to ' '
warning: called from
    display at line 135 column 3
ans = (sym) UniversalSet()  ℝ
```

with the fix:

```
octave:20> python_cmd('return S.UniversalSet - S.Reals')
warning: number of outputs don't match, was this intentional?
warning: called from
    python_cmd at line 186 column 5
ans = (sym) UniversalSet() \ ℝ
```

how we only call display when we show info this its very very very unlikely effects the performance.

The second problem, when we call some set sadly srepr don't use the same expression to show it, so for can access it from out python env we need add the sets modules.

```
octave:4> a=python_cmd('return S.Naturals')
a = (sym) ℕ
octave:5> python_cmd('return S.UniversalSet - _ins[0]', a)
Traceback (most recent call last):
  File "<stdin>", line 4, in <module>
NameError: name 'Naturals' is not defined
error: Python exception: NameError: name 'Naturals' is not defined
    occurred while copying vars to Python
error: called from
    python_cmd at line 178 column 5
```

checking the format:

```
octave:5> char(a)
ans = Naturals()
```

Why solveset? solveset returns sets depending of the domain, so when we will eval some result with it in octave we will get the same error.
