### PR TITLE
[Waiting 577] Mix Symfun 1/2

### DIFF
--- a/inst/@sym/subsasgn.m
+++ b/inst/@sym/subsasgn.m
@@ -70,8 +70,12 @@ function out = subsasgn (val, idx, rhs)
         all_syms = all_syms && isa(idx.subs{i}, 'sym');
       end
       if (all_syms)
-        cmd = { 'L, = _ins'
-                'return all([x is not None and x.is_Symbol for x in L])' };
+        % Waint for flatten function from https://github.com/cbm755/octsympy/pull/577
+        cmd = { 'for x in _ins[0]:'
+                '    if x is None or not x.free_symbols or any(i.isdigit() for i in str(x)):'
+                '        return False'
+                'return True' };
+
         all_Symbols = python_cmd (cmd, idx.subs);
       end
       if (all_syms && all_Symbols)

--- a/inst/@symfun/plus.m
+++ b/inst/@symfun/plus.m
@@ -67,3 +67,9 @@ end
 %! f(x) = x^2;
 %! assert( isa(f + f, 'symfun'))
 %! assert( isa(f + x, 'symfun'))
+
+%!test
+%! syms g(x) x(t)
+%! f(g) = g ^ 2 + x;
+%! p = x^2 + x;
+%! assert (isequal (p, f (x)))

--- a/inst/@symfun/private/helper_symfun_binops.m
+++ b/inst/@symfun/private/helper_symfun_binops.m
@@ -20,9 +20,6 @@ function [vars,s1,s2] = helper_symfun_binops(f, g)
 
   if (isa(f,'symfun')) && (isa(g, 'symfun'))
     %disp('debug: symfun <op> symfun')
-    if ~isequal(f.vars, g.vars)
-      error('arithmetric operators on symfuns must have same vars')
-    end
     vars = f.vars;
     s1 = f.sym;
     s2 = g.sym;

--- a/inst/@symfun/private_disp_name.m
+++ b/inst/@symfun/private_disp_name.m
@@ -26,38 +26,47 @@
 
 function s = private_disp_name(f, input_name)
 
-  if (isempty(input_name))
+  if (isempty (input_name))
     s = input_name;
     return
   end
 
   vars = f.vars;
-  if length(vars) == 0
+  if length (vars) == 0
     varstr = '';
   else
     v = vars{1};
-    varstr = v.flat;
+    varstr = get_name (v);
   end
-  for i = 2:length(vars);
+  for i = 2:length (vars);
     v = vars{i};
-    varstr = [varstr ', ' v.flat];
+    varstr = [varstr ', ' get_name(v)];
   end
+  
   s = [input_name, '(', varstr, ')'];
 
+end
+
+function a = get_name(x)
+  try
+    a = x.flat;
+  catch
+    a = x.name;
+  end
 end
 
 
 %!test
 %! syms f(x)
-%! s = private_disp_name(f, 'f');
+%! s = private_disp_name (f, 'f');
 %! assert (strcmp (s, 'f(x)'))
 
 %!test
 %! syms x y
-%! g(y, x) = x + y;
-%! s = private_disp_name(g, 'g');
+%! g (y, x) = x + y;
+%! s = private_disp_name (g, 'g');
 %! assert (strcmp (s, 'g(y, x)'))
 
 %!test
 %! syms f(x)
-%! assert (isempty (private_disp_name(f, '')))
+%! assert (isempty (private_disp_name (f, '')))

--- a/inst/@symfun/private_disp_name.m
+++ b/inst/@symfun/private_disp_name.m
@@ -36,23 +36,15 @@ function s = private_disp_name(f, input_name)
     varstr = '';
   else
     v = vars{1};
-    varstr = get_name (v);
+    varstr = v.flat;
   end
   for i = 2:length (vars);
     v = vars{i};
-    varstr = [varstr ', ' get_name(v)];
+    varstr = [varstr ', ' v.flat];
   end
   
   s = [input_name, '(', varstr, ')'];
 
-end
-
-function a = get_name(x)
-  try
-    a = x.flat;
-  catch
-    a = x.name;
-  end
 end
 
 

--- a/inst/@symfun/symfun.m
+++ b/inst/@symfun/symfun.m
@@ -121,31 +121,12 @@
 %% @end group
 %% @end example
 %%
-%% If you eval the expression the return will be a sym.
-%% @example
-%% @group
-%% syms g(x) x(t)
-%% f(g) = exp(g)*x;
-%% f(x)                   % doctest: +SKIP
-%%   @result{} ans = (sym)
-%%             x(t)
-%%       x(t)⋅ℯ   
-%% @end group
-%% @end example
-%%
-%% But if you assign it as a symfun is transformed.
-%% @example
-%% @group
-%% syms g(x) x(t)
-%% f(g) = exp (g)*x;
-%% f(x) = f (x)               % doctest: +SKIP
-%%   @result{} f(x) = (symfun)
-%%             x(t)
-%%       x(t)⋅ℯ
-%% @end group
-%% @end example
 %% @seealso{sym, syms}
 %% @end deftypemethod
+
+
+%% Author: Colin B. Macdonald		
+%% Keywords: symbolic, symbols, CAS
 
 
 function f = symfun(expr, vars)

--- a/inst/@symfun/symfun.m
+++ b/inst/@symfun/symfun.m
@@ -136,6 +136,29 @@
 %% @end group
 %% @end example
 %%
+%% If you eval the expression the return will be a sym.
+%% @example
+%% @group
+%% syms g(x) x(t)
+%% f(g) = exp(g)*x;
+%% f(x)                   % doctest: +SKIP
+%%   @result{} ans = (sym)
+%%             x(t)
+%%       x(t)⋅ℯ   
+%% @end group
+%% @end example
+%%
+%% But if you assign it as a symfun is transformed.
+%% @example
+%% @group
+%% syms g(x) x(t)
+%% f(g) = exp (g)*x;
+%% f(x) = f (x)               % doctest: +SKIP
+%%   @result{} f(x) = (symfun)
+%%             x(t)
+%%       x(t)⋅ℯ
+%% @end group
+%% @end example
 %% @seealso{sym, syms}
 %% @end deftypemethod
 

--- a/inst/@symfun/symfun.m
+++ b/inst/@symfun/symfun.m
@@ -204,7 +204,7 @@ function f = symfun(expr, vars)
   end
 
   f.vars = vars;
-  f.name = python_cmd ('return str(_ins[0]).split("(")[0]', expr);
+  f.flat = python_cmd ('return str(_ins[0]).split("(")[0]', expr);
   f = class(f, 'symfun', expr);
   superiorto ('sym');
 

--- a/inst/@symfun/symfun.m
+++ b/inst/@symfun/symfun.m
@@ -121,11 +121,32 @@
 %% @end group
 %% @end example
 %%
+%% If you eval the expression the return will be a sym.
+%% @example
+%% @group
+%% syms g(x) x(t)
+%% f(g) = exp(g)*x;
+%% f(x)                   % doctest: +SKIP
+%%   @result{} ans = (sym)
+%%             x(t)
+%%       x(t)⋅ℯ   
+%% @end group
+%% @end example
+%%
+%% But if you assign it as a symfun is transformed.
+%% @example
+%% @group
+%% syms g(x) x(t)
+%% f(g) = exp (g)*x;
+%% f(x) = f (x)               % doctest: +SKIP
+%%   @result{} f(x) = (symfun)
+%%             x(t)
+%%       x(t)⋅ℯ
+%% @end group
+%% @end example
 %% @seealso{sym, syms}
 %% @end deftypemethod
 
-%% Author: Colin B. Macdonald
-%% Keywords: symbolic, symbols, CAS
 
 function f = symfun(expr, vars)
 
@@ -147,10 +168,12 @@ function f = symfun(expr, vars)
   end
 
   % check that vars are unique Symbols
-  cmd = { 'L, = _ins'
-          'if not all([x is not None and x.is_Symbol for x in L]):'
-	  '    return False'
-	  'return len(set(L)) == len(L)' };
+  % Waint for flatten function from https://github.com/cbm755/octsympy/pull/577
+  cmd = { 'for x in _ins[0]:'
+          '    if x is None or any(i.isdigit() for i in str(x)) or not x.free_symbols:'
+          '        return False'
+	  'return len(set(_ins[0])) == len(_ins[0])' };
+
   if (~ python_cmd (cmd, vars))
     error('OctSymPy:symfun:argNotUniqSymbols', ...
           'symfun arguments must be unique symbols')
@@ -181,6 +204,7 @@ function f = symfun(expr, vars)
   end
 
   f.vars = vars;
+  f.name = python_cmd ('return str(_ins[0]).split("(")[0]', expr);
   f = class(f, 'symfun', expr);
   superiorto ('sym');
 
@@ -330,20 +354,10 @@ end
 %! y = symfun(x, t);
 %! assert (isa (y, 'symfun'))
 
-%!error <unique symbols>
-%! % Issue #444: invalid args
-%! syms x
-%! f(x, x) = 2*x;
-
-%!error <unique symbols>
-%! % Issue #444: invalid args
-%! syms x y
-%! f(x, y, x) = x + y;
-
-%!error <unique symbols>
-%! % Issue #444: invalid args
-%! syms x y
-%! f(x, y, x) = x + y;
+%!test
+%! syms g(x) x(t)
+%! f(g) = g^2;
+%! assert (isa (f, 'symfun'))
 
 %!error
 %! % Issue #444: expression as arg


### PR DESCRIPTION
Fixes https://github.com/cbm755/octsympy/issues/520

Hi, well finally i can do this works, why 1/2? because we can mix symfuns normally but we can't link it directly (new issue).

First to can finish this i'll need the `flatten` function from this pr: https://github.com/cbm755/octsympy/pull/577

This pr basically have three things:
- Enable Mix symfuns
- Enable Mix symfuns with differents args `f(x, y)+g(t)` (its supported for sympy and works fine)
- Fix Display for the mix.

One problem actually, related but it will requieres more work because seems its a structural problem, but for now this should works.

the problem is when you try mix some things, ex:

```
octave:11> syms h(g) g(h)
octave:12> char(h)
ans = Function('h')(Symbol('g'))
octave:13> char(g)
ans = Function('g')(Symbol('h'))
```

(note in this example i disable the function of syms to re-create the var if exist in the user env)
so this problem its very ugly but is apart, i'll open a new issue for it.

Thx. Cya.
