### PR TITLE
[travis] Correctly set python version

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,19 +5,17 @@ language: generic
 
 matrix:
   include:
-    - python: "2.7"
-      env: PYTAVE=no  SYMPY_VER=1.0 OCT_PPA=yes DOCTEST=yes COLUMNS=80
-    - python: "3.5"
-      env: PYTAVE=no  SYMPY_VER=1.0 OCT_PPA=yes DOCTEST=yes COLUMNS=80
+    - env: PYTHON_VER="" PYTAVE=no  SYMPY_VER=1.0 OCT_PPA=yes DOCTEST=yes COLUMNS=80
+    - env: PYTHON_VER="3" PYTAVE=no  SYMPY_VER=1.0 OCT_PPA=yes DOCTEST=yes COLUMNS=80
 
 # need octave devel pkgs for doctest (has compiled code as of July 2015)
 install:
   - if [ "x$OCT_PPA" = "xyes" ]; then
         sudo apt-add-repository -y ppa:octave/stable;
     fi
-  - sudo apt-get update -qq -y;
-  - sudo apt-get install -qq -y octave liboctave-dev;
-  - sudo apt-get install -qq -y python;
+  - sudo apt-get update -y;
+  - sudo apt-get install -y octave liboctave-dev;
+  - sudo apt-get install -y python$PYTHON_VER;
   - "pip install --user sympy==$SYMPY_VER"
   - if [ "x$DOCTEST" = "xyes" ]; then
         octave -W --no-gui --eval "pkg install -forge doctest";

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,11 +5,11 @@ language: generic
 
 matrix:
   include:
-    - env: PYTHON_VER="" PYTAVE=no  SYMPY_VER=1.0 OCT_PPA=yes DOCTEST=yes COLUMNS=80
-    - env: PYTHON_VER="3" PYTAVE=no  SYMPY_VER=1.0 OCT_PPA=yes DOCTEST=yes COLUMNS=80
+    - env: PYTHON=python2 PYTHON_VER="" PYTAVE=no  SYMPY_VER=1.0 OCT_PPA=yes DOCTEST=yes COLUMNS=80
+    - env: PYTHON=python3 PYTHON_VER="3" PYTAVE=no  SYMPY_VER=1.0 OCT_PPA=yes DOCTEST=yes COLUMNS=80
 
 # need octave devel pkgs for doctest (has compiled code as of July 2015)
-install:
+before_install:
   - if [ "x$OCT_PPA" = "xyes" ]; then
         sudo apt-add-repository -y ppa:octave/stable;
     fi
@@ -21,7 +21,7 @@ install:
         octave -W --no-gui --eval "pkg install -forge doctest";
     fi
   - if [ "x$PYTAVE" = "xyes" ]; then
-        sudo apt-get install -qq -y libboost-python-dev python-numpy;
+        sudo apt-get install -qq -y libboost-python-dev python$PYTHON_VER-numpy;
         hg clone https://bitbucket.org/genuinelucifer/pytave_main;
         mv pytave_main pytave;
         pushd pytave;

--- a/.travis.yml
+++ b/.travis.yml
@@ -15,8 +15,8 @@ install:
     fi
   - sudo apt-get update -y;
   - sudo apt-get install -y octave liboctave-dev;
-  - sudo apt-get install -y python$PYTHON_VER;
-  - "pip install --user sympy==$SYMPY_VER"
+  - sudo apt-get install -y python$PYTHON_VER-pip;
+  - "pip$PYTHON_VER install --user sympy==$SYMPY_VER"
   - if [ "x$DOCTEST" = "xyes" ]; then
         octave -W --no-gui --eval "pkg install -forge doctest";
     fi


### PR DESCRIPTION
`language: generic` does not offer different versions of python.
The ones provided by trusty are python and python3.

Fixes: #586