### PR TITLE
Rename pytave to native Python/C interface

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -53,8 +53,8 @@ octsympy 2.5.0-dev
 
   * `isfinite` behaves correctly for variables (and is documented).
 
-  * New experimental Python communication using Pytave, due to
-    Abhinav Tripathi during Google Summer of Code 2016.
+  * New experimental Python communication using the native Python/C
+    interface, due to Abhinav Tripathi during Google Summer of Code 2016.
 
   * Bug fix: assign `[]` to row/column removes that that row/column.
 

--- a/inst/private/python_ipc_driver.m
+++ b/inst/private/python_ipc_driver.m
@@ -44,7 +44,7 @@ function [A, db] = python_ipc_driver(what, cmd, varargin)
 
   if (strcmp(lower(which_ipc), 'default'))
     if ((exist('pyeval') > 1) && (exist('pyexec') > 1))
-      which_ipc = 'pytave';
+      which_ipc = 'native';
     elseif (exist('popen2') > 1)
       which_ipc = 'popen2';
     else
@@ -53,8 +53,8 @@ function [A, db] = python_ipc_driver(what, cmd, varargin)
   end
 
   switch lower(which_ipc)
-    case 'pytave'
-      [A, db] = python_ipc_pytave(what, cmd, varargin{:});
+    case 'native'
+      [A, db] = python_ipc_native(what, cmd, varargin{:});
 
     case 'popen2'
       [A, db] = python_ipc_popen2(what, cmd, varargin{:});

--- a/inst/private/python_ipc_native.m
+++ b/inst/private/python_ipc_native.m
@@ -18,7 +18,7 @@
 %% If not, see <http://www.gnu.org/licenses/>.
 
 %% -*- texinfo -*-
-%% @deftypefn  {Function File}  {[@var{A}, @var{info}] =} python_ipc_pytave (@dots{})
+%% @deftypefn  {Function File}  {[@var{A}, @var{info}] =} python_ipc_native (@dots{})
 %% Private helper function for Python IPC.
 %%
 %% @var{A} is the resulting object, which might be an error code.
@@ -31,7 +31,7 @@
 %%
 %% @end deftypefn
 
-function [A, info] = python_ipc_pytave(what, cmd, varargin)
+function [A, info] = python_ipc_native(what, cmd, varargin)
 
   persistent show_msg
   persistent have_headers
@@ -53,7 +53,7 @@ function [A, info] = python_ipc_pytave(what, cmd, varargin)
   if (verbose && isempty(show_msg))
     fprintf('OctSymPy v%s: this is free software without warranty, see source.\n', ...
             sympref('version'))
-    disp('Using experimental PyTave communications with SymPy.')
+    disp('Using experimental native Python/C communications with SymPy.')
     show_msg = true;
   end
 

--- a/inst/python_cmd.m
+++ b/inst/python_cmd.m
@@ -425,7 +425,7 @@ end
 %! assert (isequal (a, 6))
 
 %!xtest error <octoutput does not know how to export type>
-%! % This command does not fail with PyTave and '@pyobject'
+%! % This command does not fail with native interface and '@pyobject'
 %! python_cmd({'return type(int)'});
 %!test
 %! % ...and after the above test, the pipe should still work

--- a/inst/sympref.m
+++ b/inst/sympref.m
@@ -288,8 +288,8 @@ function varargout = sympref(cmd, arg)
         switch arg
           case 'default'
             msg = 'Choosing the default [autodetect] communication mechanism';
-          case 'pytave'
-            msg = 'Forcing the PyTave communication mechanism';
+          case 'native'
+            msg = 'Forcing the native Python/C API communication mechanism';
           case 'system'
             msg = 'Forcing the system() communication mechanism';
           case 'popen2'


### PR DESCRIPTION
Excludes explicit references and comments about pytave as a project.
Fixes #593.