### PR TITLE
Fix typo in heaviside test printing an empty plot

### DIFF
--- a/inst/@sym/heaviside.m
+++ b/inst/@sym/heaviside.m
@@ -90,7 +90,7 @@ end
 
 %!test
 %! if (python_cmd ('return Version(spver) <= Version("1.0")'))
-%! print ('skipping test, sympy too old')
+%! disp ('skipping test, sympy too old')
 %! else
 %! H0 = sym([1 -2 0; 3 0 pi]);
 %! A = heaviside (sym(0), H0);


### PR DESCRIPTION
This looks like it was just a typo/thinko. But the end result for me was a file "skipping test, sympy too old.ps" appearing whenever I ran the test suite.