### PR TITLE
docs: fix double quotes in texinfo

### DIFF
--- a/inst/@sym/ccode.m
+++ b/inst/@sym/ccode.m
@@ -74,10 +74,10 @@
 %% @end group
 %% @end example
 %%
-%% FIXME: This doesn't write "optimized" code like Matlab's
-%% Symbolic Math Toolbox; it doesn't do "Common Subexpression
-%% Elimination".  Presumably the compiler would do that for us
-%% anyway.  Sympy has a "cse" module that will do it.  See:
+%% FIXME: This doesn't write ``optimized'' code like Matlab's
+%% Symbolic Math Toolbox; it doesn't do ``Common Subexpression
+%% Elimination''.  Presumably the compiler would do that for us
+%% anyway.  Sympy has a ``cse'' module that will do it.  See:
 %% http://stackoverflow.com/questions/22665990/optimize-code-generated-by-sympy
 %%
 %% @seealso{@@sym/fortran, @@sym/latex, @@ssym/function_handle}

--- a/inst/@sym/fortran.m
+++ b/inst/@sym/fortran.m
@@ -71,10 +71,10 @@
 %% @end group
 %% @end example
 %%
-%% FIXME: This doesn't write "optimized" code like Matlab's
-%% Symbolic Math Toolbox; it doesn't do "Common Subexpression
-%% Elimination".  Presumably the compiler would do that for us
-%% anyway.  Sympy has a "cse" module that will do it.  See:
+%% FIXME: This doesn't write ``optimized'' code like Matlab's
+%% Symbolic Math Toolbox; it doesn't do ``Common Subexpression
+%% Elimination''.  Presumably the compiler would do that for us
+%% anyway.  Sympy has a ``cse'' module that will do it.  See:
 %% http://stackoverflow.com/questions/22665990/optimize-code-generated-by-sympy
 %%
 %% @seealso{@@sym/ccode, @@sym/latex, @@sym/function_handle}

--- a/inst/@sym/isinf.m
+++ b/inst/@sym/isinf.m
@@ -50,8 +50,8 @@
 %% @end example
 %% Here SymPy would have said @code{None} as it does not know whether
 %% x is finite or not.  However, currently @code{isinf} returns
-%% false, which perhaps should be interpreted as "x cannot be shown to
-%% be infinite" (as opposed to "x is not infinite").
+%% false, which perhaps should be interpreted as ``x cannot be shown to
+%% be infinite'' (as opposed to ``x is not infinite'').
 %%
 %% FIXME: this is behaviour might change in a future version; come
 %% discuss at @url{https://github.com/cbm755/octsympy/issues/308}.

--- a/inst/@sym/psi.m
+++ b/inst/@sym/psi.m
@@ -22,7 +22,7 @@
 %% @defmethodx @@sym psi (@var{k}, @var{x})
 %% Symbolic polygamma function.
 %%
-%% The first polygamma (or "psi") function is the logarithmic
+%% The first polygamma (or ``psi'') function is the logarithmic
 %% derivative of the gamma function:
 %% @example
 %% @group

--- a/inst/@sym/times.m
+++ b/inst/@sym/times.m
@@ -33,7 +33,7 @@
 %% @end group
 %% @end example
 %%
-%% For "matrix expressions" such as matrices with symbolic size,
+%% For ``matrix expressions'' such as matrices with symbolic size,
 %% the product may not be evaluated:
 %% @example
 %% @group

--- a/inst/dirac.m
+++ b/inst/dirac.m
@@ -19,7 +19,7 @@
 %% @defun dirac (@var{x})
 %% Compute the Dirac delta (generalized) function.
 %%
-%% The Dirac delta "function" is a generalized function (or distribution)
+%% The Dirac delta ``function'' is a generalized function (or distribution)
 %% which is zero almost everywhere, except at the origin where it is
 %% infinite.
 %%

--- a/inst/evalpy.m
+++ b/inst/evalpy.m
@@ -92,7 +92,7 @@
 %% @itemize
 %% @item if you assign to @var{x} but don't change its value,
 %%   it will not be assigned to and will not appear in the
-%%   Variables effected:" list.
+%%   ``Variables effected'' list.
 %% @item using print is probably a bad idea.  For now, use
 %%   @code{dbout(x)} to print @code{x} to stderr which should
 %%   appear in the terminal (FIXME: currently broken on windows).

--- a/inst/sympref.m
+++ b/inst/sympref.m
@@ -109,7 +109,7 @@
 %% @item @code{sympref ipc native}: use native Python/C interface to
 %% interact directly with an embedded Python interpreter.
 %% This is highly experimental and requires functions provided by the
-%% "pytave" project which have not yet been merged into Octave.
+%% ``pytave'' project which have not yet been merged into Octave.
 %% @item @code{sympref ipc system}: construct a long string of
 %% the command and pass it directly to the python interpreter with
 %% the @code{system()} command.  This typically assembles a multiline


### PR DESCRIPTION
Use LaTeX-style backtics and apostrophes.
