### PR TITLE
Fixes for `sympref ipc`

### DIFF
--- a/inst/private/python_ipc_driver.m
+++ b/inst/private/python_ipc_driver.m
@@ -43,9 +43,7 @@ function [A, db] = python_ipc_driver(what, cmd, varargin)
   end
 
   if (strcmp(lower(which_ipc), 'default'))
-    if ((exist('pyeval') > 1) && (exist('pyexec') > 1))
-      which_ipc = 'native';
-    elseif (exist('popen2') > 1)
+    if (exist('popen2') > 1)
       which_ipc = 'popen2';
     else
       which_ipc = 'system';

--- a/inst/sympref.m
+++ b/inst/sympref.m
@@ -304,7 +304,12 @@ function varargout = sympref(cmd, arg)
             msg = 'Forcing sysoneline ipc: warning: this is for debugging';
           otherwise
             msg = '';
-            warning('Unsupported IPC mechanism: hope you know what you''re doing')
+            if (~ ischar (arg))
+              arg = num2str (arg);
+            end
+            warning('OctSymPy:sympref:invalidarg', ...
+                    'Unsupported IPC mechanism ''%s'': hope you know what you''re doing', ...
+                    arg)
         end
         if (verbose)
           disp(msg)


### PR DESCRIPTION
Fix for #611, and a small improvement to the `sympref ipc` warning message when an invalid argument is passed in.