### PR TITLE
Fix round to do the right thing on complex numbers

### DIFF
--- a/inst/@sym/round.m
+++ b/inst/@sym/round.m
@@ -37,7 +37,7 @@ function y = round(x)
   if (nargin ~= 1)
     print_usage ();
   end
-  y = elementwise_op ('lambda a: Integer(a.round())', x);
+  y = elementwise_op ('lambda a: Integer(a.round()) if isinstance(a, Number) else a.round()', x);
 end
 
 
@@ -71,3 +71,17 @@ end
 %! d = sym(-19)/10;
 %! c = -2;
 %! assert (isequal (round (d), c))
+
+%!test
+%! d = 5j/2;
+%! x = sym(5j)/2;
+%! f1 = round (x);
+%! f2 = round (d);
+%! assert (isequal (f1, f2))
+
+%!test
+%! d = 5/3 - 4j/7;
+%! x = sym(5)/3 - sym(4j)/7;
+%! f1 = round (x);
+%! f2 = round (d);
+%! assert (isequal (f1, f2))


### PR DESCRIPTION
Add conditional logic to round all Number values to the nearest Integer,
but still allow round to operate normally on expressions such as complex
numbers. Fixes #643.