### PR TITLE
`rewrite` can use the new elementwise_op

### DIFF
--- a/inst/@sym/rewrite.m
+++ b/inst/@sym/rewrite.m
@@ -100,16 +100,7 @@ function F = rewrite(f, how)
     print_usage ();
   end
 
-  cmd = { '(f, how) = _ins'
-          '# note, not for MatrixExpr'
-          'if isinstance(f, sp.MatrixBase):'
-          '    return f.applyfunc(lambda a: a.rewrite(how)),'
-          'else:'
-          '    return f.rewrite(how),' };
-
-  F = python_cmd(cmd, sym(f), how);
-
-  % maintainer note: elementwise_op might sym(how)
+  F = elementwise_op ('lambda f, how: f.rewrite(how)', sym(f), how);
 
 end
 


### PR DESCRIPTION
It's currently broken, probably because of #650.

Try this again, after #653 goes in.