### PR TITLE
Fix syntax error in native ipc driver

### DIFF
--- a/inst/private/python_ipc_native.m
+++ b/inst/private/python_ipc_native.m
@@ -73,7 +73,7 @@ function [A, info] = python_ipc_native(what, cmd, varargin)
                     'from sympy.matrices.expressions.matexpr import MatrixElement'
                     '# for hypergeometric'
                     'from sympy.functions.special.hyper import TupleArg'
-                    '# for sets
+                    '# for sets'
                     'from sympy.sets.fancysets import *'
                     'from sympy.sets.sets import *'
                     'from sympy.utilities.iterables import uniq'


### PR DESCRIPTION
Add missing quote from commit eb8076e5f41e3403bc53b2c01af47de295e210d9.

Fixes the native (pytave) interface, apparently broken in PR #583.