### PR TITLE
limit: use a dummy var if neither symvar nor user give one

### DIFF
--- a/inst/@sym/limit.m
+++ b/inst/@sym/limit.m
@@ -85,7 +85,8 @@ function L = limit(f, x, a, dir)
   end
 
   if (isempty (x))
-    x = sym('x');
+    L = f;
+    return
   end
 
   cmd = { '(f, x, a, pdir) = _ins'

--- a/inst/@sym/limit.m
+++ b/inst/@sym/limit.m
@@ -62,6 +62,7 @@ function L = limit(f, x, a, dir)
     print_usage ();
   end
 
+  f = sym(f);
   if (nargin < 4)
     dir= 'right';
   end
@@ -141,3 +142,9 @@ end
 %! assert (isequal (limit(sym(6)), 6))
 %! assert (isequal (limit(sym(6), 7), 6))
 %! assert (isequal (limit([sym(6) sym(2)], 7), [6 2]))
+
+%!test
+%! % double constant, with sym limit
+%! a = limit (6, sym(0));
+%! assert (isa (a, 'sym'))
+%! assert (isequal (a, sym(6)))

--- a/inst/@sym/limit.m
+++ b/inst/@sym/limit.m
@@ -83,6 +83,10 @@ function L = limit(f, x, a, dir)
       print_usage ();
   end
 
+  if (isempty (x))
+    x = sym('x');
+  end
+
   cmd = { '(f, x, a, pdir) = _ins'
           '# note, not MatrixExpr'
           'if isinstance(f, sp.MatrixBase):'
@@ -128,7 +132,12 @@ end
 %!test
 %! % omitting arguments
 %! syms a
+%! assert (isequal (limit(a), 0))
 %! assert (isequal (limit(a*x+a+2), a+2))
 %! assert (isequal (limit(a*x+a+2, 6), 7*a+2))
+
+%!test
+%! % constants
 %! assert (isequal (limit(sym(6)), 6))
 %! assert (isequal (limit(sym(6), 7), 6))
+%! assert (isequal (limit([sym(6) sym(2)], 7), [6 2]))


### PR DESCRIPTION
Fixes #669.