### PR TITLE
Elliptic

### DIFF
--- a/inst/@sym/ellipke.m
+++ b/inst/@sym/ellipke.m
@@ -1,0 +1,97 @@
+%% Copyright (C) 2016 Lagu
+%%
+%% This file is part of OctSymPy.
+%%
+%% OctSymPy is free software; you can redistribute it and/or modify
+%% it under the terms of the GNU General Public License as published
+%% by the Free Software Foundation; either version 3 of the License,
+%% or (at your option) any later version.
+%%
+%% This software is distributed in the hope that it will be useful,
+%% but WITHOUT ANY WARRANTY; without even the implied warranty
+%% of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See
+%% the GNU General Public License for more details.
+%%
+%% You should have received a copy of the GNU General Public
+%% License along with this software; see the file COPYING.
+%% If not, see <http://www.gnu.org/licenses/>.
+
+%% -*- texinfo -*-
+%% @documentencoding UTF-8
+%% @defmethod @@sym [K E] = ellipke (@var{m})
+%% Complete elliptic integrals of the first and second kinds.
+%%
+%% Example:
+%% @example
+%% @group
+%% syms m
+%% [K E] = ellipke (m)
+%%   @result{}
+%%     K = (sym) K(m)
+%%     E = (sym) E(m)
+%% @end group
+%%
+%% @group
+%% rewrite (K, 'Integral')         % doctest: +SKIP
+%%   @result{}
+%%     K = (sym)
+%%       π
+%%       ─
+%%       2
+%%       ⌠
+%%       ⎮          1
+%%       ⎮ ──────────────────── dα
+%%       ⎮    _________________
+%%       ⎮   ╱        2
+%%       ⎮ ╲╱  - m⋅sin (α) + 1
+%%       ⌡
+%%       0
+%% @end group
+%%
+%% @group
+%% rewrite (E, 'Integral')         % doctest: +SKIP
+%%     E = (sym)
+%%
+%%       π
+%%       ─
+%%       2
+%%       ⌠
+%%       ⎮
+%%       ⎮   ╱        2
+%%       ⎮ ╲╱  - m⋅sin (α) + 1  dα
+%%       ⌡
+%%       0
+%% @end group
+%% @group
+%% [K E] = ellipke (sym (1)/10);
+%% double ([K E])
+%%   @result{} ans =
+%%        1.6124   1.5308
+%% @end group
+%% @end example
+%%
+%% @seealso{@@sym/ellipticF, @@sym/ellipticE, @@sym/ellipticPi}
+%% @end defmethod
+
+
+function varargout = ellipke(m)
+
+  if (nargin ~= 1 || nargout > 2)
+    print_usage ();
+  end
+
+  if (nargout == 0 || nargout == 1)
+    varargout = {ellipticF(sym (pi)/2, m)};
+  else
+    varargout = {ellipticF(sym (pi)/2, m) ellipticE(sym (pi)/2, m)};
+  end
+
+end
+
+
+%!test
+%! for i = 2:10
+%!   [K E] = ellipke (sym (1)/i);
+%!   [k e] = ellipke (1/i);
+%!   assert (double ([K E]), [k e], 2*eps)
+%! end

--- a/inst/@sym/ellipticCE.m
+++ b/inst/@sym/ellipticCE.m
@@ -1,0 +1,68 @@
+%% Copyright (C) 2016 Lagu
+%%
+%% This file is part of OctSymPy.
+%%
+%% OctSymPy is free software; you can redistribute it and/or modify
+%% it under the terms of the GNU General Public License as published
+%% by the Free Software Foundation; either version 3 of the License,
+%% or (at your option) any later version.
+%%
+%% This software is distributed in the hope that it will be useful,
+%% but WITHOUT ANY WARRANTY; without even the implied warranty
+%% of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See
+%% the GNU General Public License for more details.
+%%
+%% You should have received a copy of the GNU General Public
+%% License along with this software; see the file COPYING.
+%% If not, see <http://www.gnu.org/licenses/>.
+
+%% -*- texinfo -*-
+%% @documentencoding UTF-8
+%% @defmethod @@sym ellipticCE (@var{m})
+%% Complementary complete elliptic integral of the second kind.
+%%
+%% Example:
+%% @example
+%% @group
+%% syms m
+%% ellipticCE (m)
+%%   @result{} ans = (sym) E(-m + 1)
+%% @end group
+%%
+%% @group
+%% rewrite (ans, 'Integral')         % doctest: +SKIP
+%%   @result{} ans = (sym)
+%%       π
+%%       ─
+%%       2
+%%       ⌠
+%%       ⎮    ________________________
+%%       ⎮   ╱               2
+%%       ⎮ ╲╱  - (-m + 1)⋅sin (α) + 1  dα
+%%       ⌡
+%%       0
+%% @end group
+%% @group
+%% double (ellipticCE (sym (pi)/4))
+%%   @result{} ans =  1.4828
+%% @end group
+%% @end example
+%%
+%% @seealso{@@sym/ellipticE}
+%% @end defmethod
+
+
+function y = ellipticCE(m)
+  if nargin > 1
+    print_usage();
+  end
+
+  y = ellipticE (sym (pi)/2, 1 - m);
+
+end
+
+
+%!assert (double (ellipticCE (sym (0))), 1)
+%!assert (double (ellipticCE (sym (pi)/4)), 1.482786927, 10e-10)
+%!assert (double (ellipticCE (sym (1))), 1.570796327, 10e-10)
+%!assert (double (ellipticCE (sym (pi)/2)), 1.775344699, 10e-1)

--- a/inst/@sym/ellipticCK.m
+++ b/inst/@sym/ellipticCK.m
@@ -1,0 +1,67 @@
+%% Copyright (C) 2016 Lagu
+%%
+%% This file is part of OctSymPy.
+%%
+%% OctSymPy is free software; you can redistribute it and/or modify
+%% it under the terms of the GNU General Public License as published
+%% by the Free Software Foundation; either version 3 of the License,
+%% or (at your option) any later version.
+%%
+%% This software is distributed in the hope that it will be useful,
+%% but WITHOUT ANY WARRANTY; without even the implied warranty
+%% of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See
+%% the GNU General Public License for more details.
+%%
+%% You should have received a copy of the GNU General Public
+%% License along with this software; see the file COPYING.
+%% If not, see <http://www.gnu.org/licenses/>.
+
+%% -*- texinfo -*-
+%% @documentencoding UTF-8
+%% @defmethod @@sym ellipticCK (@var{m})
+%% Complementary complete elliptic integral of the first kind.
+%%
+%% Example:
+%% @example
+%% @group
+%% syms m
+%% ellipticCK (m)
+%%   @result{} ans = (sym) K(m)
+%% @end group
+%%
+%% @group
+%% rewrite (ans, 'Integral')         % doctest: +SKIP
+%%   @result{} ans = (sym)
+%%       π
+%%       ─
+%%       2
+%%       ⌠
+%%       ⎮          1
+%%       ⎮ ──────────────────── dα
+%%       ⎮    _________________
+%%       ⎮   ╱        2
+%%       ⎮ ╲╱  - m⋅sin (α) + 1
+%%       ⌡
+%%       0
+%% @end group
+%% @group
+%% double (ellipticCK (sym (1)/2))
+%%   @result{} ans =  1.8541
+%% @end group
+%% @end example
+%%
+%% @seealso{@@sym/ellipticF, @@sym/ellipticPi}
+%% @end defmethod
+
+
+function y = ellipticCK(m)
+  if nargin > 1
+    print_usage();
+  end
+
+  y = ellipticF (sym (pi)/2, m);
+
+end
+
+
+%!assert (double (ellipticCK (sym (1)/2)), 1.8541, 10e-5)

--- a/inst/@sym/ellipticCPi.m
+++ b/inst/@sym/ellipticCPi.m
@@ -1,0 +1,67 @@
+%% Copyright (C) 2016 Lagu
+%%
+%% This file is part of OctSymPy.
+%%
+%% OctSymPy is free software; you can redistribute it and/or modify
+%% it under the terms of the GNU General Public License as published
+%% by the Free Software Foundation; either version 3 of the License,
+%% or (at your option) any later version.
+%%
+%% This software is distributed in the hope that it will be useful,
+%% but WITHOUT ANY WARRANTY; without even the implied warranty
+%% of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See
+%% the GNU General Public License for more details.
+%%
+%% You should have received a copy of the GNU General Public
+%% License along with this software; see the file COPYING.
+%% If not, see <http://www.gnu.org/licenses/>.
+
+%% -*- texinfo -*-
+%% @documentencoding UTF-8
+%% @defmethod @@sym ellipticCPi (@var{n}, @var{m})
+%% Complementary complete elliptic integral of the third kind.
+%%
+%% Example:
+%% @example
+%% @group
+%% syms n m
+%% ellipticCPi (n, m)
+%%   @result{} ans = (sym) Π(n│m)
+%% @end group
+%%
+%% @group
+%% rewrite (ans, 'Integral')         % doctest: +SKIP
+%%   @result{} ans = (sym)
+%%       π
+%%       ─
+%%       2
+%%       ⌠
+%%       ⎮                   1
+%%       ⎮ ────────────────────────────────────── dα
+%%       ⎮    _________________
+%%       ⎮   ╱        2         ⎛       2       ⎞
+%%       ⎮ ╲╱  - m⋅sin (α) + 1 ⋅⎝- n⋅sin (α) + 1⎠
+%%       ⌡
+%%       0
+%% @end group
+%% @group
+%% double (ellipticCPi (sym (0), sym (1)/2))
+%%   @result{} ans =  1.8541
+%% @end group
+%% @end example
+%%
+%% @seealso{@@sym/ellipticPi}
+%% @end defmethod
+
+
+function y = ellipticCPi(n, m)
+  if nargin ~= 2
+    print_usage();
+  end
+
+  y = ellipticPi (n, sym (pi)/2, m);
+
+end
+
+
+%!assert (double (ellipticCPi (0, sym (1)/2)), 1.854074677, 10e-10)

--- a/inst/@sym/ellipticE.m
+++ b/inst/@sym/ellipticE.m
@@ -1,0 +1,101 @@
+%% Copyright (C) 2016 Lagu
+%% Copyright (C) 2017 Colin B. Macdonald
+%%
+%% This file is part of OctSymPy.
+%%
+%% OctSymPy is free software; you can redistribute it and/or modify
+%% it under the terms of the GNU General Public License as published
+%% by the Free Software Foundation; either version 3 of the License,
+%% or (at your option) any later version.
+%%
+%% This software is distributed in the hope that it will be useful,
+%% but WITHOUT ANY WARRANTY; without even the implied warranty
+%% of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See
+%% the GNU General Public License for more details.
+%%
+%% You should have received a copy of the GNU General Public
+%% License along with this software; see the file COPYING.
+%% If not, see <http://www.gnu.org/licenses/>.
+
+%% -*- texinfo -*-
+%% @documentencoding UTF-8
+%% @defmethod @@sym ellipticE (@var{m})
+%% @defmethodx @@sym ellipticE (@var{phi}, @var{m})
+%% Complete and incomplete elliptic integrals of the second kind.
+%%
+%% Incomplete elliptic integral of the second kind:
+%% @example
+%% @group
+%% syms phi m
+%% ellipticE (phi, m)
+%%   @result{} ans = (sym) E(φ│m)
+%% @end group
+%%
+%% @group
+%% rewrite (ans, 'Integral')         % doctest: +SKIP
+%%   @result{} ans = (sym)
+%%       φ
+%%       ⌠
+%%       ⎮    _________________
+%%       ⎮   ╱        2
+%%       ⎮ ╲╱  - m⋅sin (α) + 1  dα
+%%       ⌡
+%%       0
+%% @end group
+%%
+%% @group
+%% double (ellipticE (sym (1), sym (1)/10))
+%%   @result{} ans =  0.98621
+%% @end group
+%% @end example
+%%
+%% Complete elliptic integral of the second kind:
+%% @example
+%% @group
+%% ellipticE (m)
+%%   @result{} ans = (sym) E(m)
+%% @end group
+%%
+%% @group
+%% rewrite (ans, 'Integral')         % doctest: +SKIP
+%%   @result{} ans = (sym)
+%%       π
+%%       ─
+%%       2
+%%       ⌠
+%%       ⎮    _________________
+%%       ⎮   ╱        2
+%%       ⎮ ╲╱  - m⋅sin (α) + 1  dα
+%%       ⌡
+%%       0
+%% @end group
+%%
+%% @group
+%% double (ellipticE (sym (-pi)/4))
+%%   @result{} ans =  1.8443
+%% @end group
+%% @end example
+%% @seealso{@@sym/ellipticK, ellipke}
+%% @end defmethod
+
+
+function y = ellipticE(phi, m)
+
+  if (nargin == 1)
+    m = phi;
+    phi = sym (pi)/2;
+  elseif (nargin == 2)
+    % no-op
+  else
+    print_usage ();
+  end
+
+  y = elementwise_op ('elliptic_e', sym (phi), sym (m));
+
+end
+
+
+%!assert (double (ellipticE (sym (-105)/10)), 3.70961391, 10e-9)
+%!assert (double (ellipticE (sym (-pi)/4)), 1.844349247, 10e-10)
+%!assert (double (ellipticE (sym (0))), 1.570796327, 10e-10)
+%!assert (double (ellipticE (sym (1))), 1, 10e-1)

--- a/inst/@sym/ellipticF.m
+++ b/inst/@sym/ellipticF.m
@@ -1,0 +1,70 @@
+%% Copyright (C) 2016 Lagu
+%%
+%% This file is part of OctSymPy.
+%%
+%% OctSymPy is free software; you can redistribute it and/or modify
+%% it under the terms of the GNU General Public License as published
+%% by the Free Software Foundation; either version 3 of the License,
+%% or (at your option) any later version.
+%%
+%% This software is distributed in the hope that it will be useful,
+%% but WITHOUT ANY WARRANTY; without even the implied warranty
+%% of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See
+%% the GNU General Public License for more details.
+%%
+%% You should have received a copy of the GNU General Public
+%% License along with this software; see the file COPYING.
+%% If not, see <http://www.gnu.org/licenses/>.
+
+%% -*- texinfo -*-
+%% @documentencoding UTF-8
+%% @defmethod @@sym ellipticF (@var{phi}, @var{m})
+%% Incomplete elliptic integral of the first kind.
+%%
+%% Example:
+%% @example
+%% @group
+%% syms phi m
+%% ellipticF (phi, m)
+%%   @result{} ans = (sym) F(φ│m)
+%% @end group
+%%
+%% @group
+%% rewrite (ans, 'Integral')         % doctest: +SKIP
+%%   @result{} ans = (sym)
+%%       φ
+%%       ⌠
+%%       ⎮          1
+%%       ⎮ ──────────────────── dα
+%%       ⎮    _________________
+%%       ⎮   ╱        2
+%%       ⎮ ╲╱  - m⋅sin (α) + 1
+%%       ⌡
+%%       0
+%% @end group
+%% @group
+%% double (ellipticF (sym (1), sym (-1)))
+%%   @result{} ans =  0.89639
+%% @end group
+%% @end example
+%%
+%% @seealso{@@sym/ellipticPi}
+%% @end defmethod
+
+
+function y = ellipticF(phi, m)
+
+  if nargin ~= 2
+    print_usage ();
+  end
+
+% y = ellipticPi (0, phi, m);
+  y = elementwise_op ('elliptic_f', phi, m);
+
+end
+
+
+%!assert (double (ellipticF (sym (pi)/3, sym (-105)/10)), 0.6184459461, 10e-11)
+%!assert (double (ellipticF (sym (pi)/4, sym (-pi))), 0.6485970495, 10e-11)
+%!assert (double (ellipticF (sym (1), sym (-1))), 0.8963937895, 10e-11)
+%!assert (double (ellipticF (sym (pi)/6, sym (0))), 0.5235987756, 10e-11)

--- a/inst/@sym/ellipticK.m
+++ b/inst/@sym/ellipticK.m
@@ -1,0 +1,91 @@
+%% Copyright (C) 2016 Lagu
+%% Copyright (C) 2017 Colin B. Macdonald
+%%
+%% This file is part of OctSymPy.
+%%
+%% OctSymPy is free software; you can redistribute it and/or modify
+%% it under the terms of the GNU General Public License as published
+%% by the Free Software Foundation; either version 3 of the License,
+%% or (at your option) any later version.
+%%
+%% This software is distributed in the hope that it will be useful,
+%% but WITHOUT ANY WARRANTY; without even the implied warranty
+%% of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See
+%% the GNU General Public License for more details.
+%%
+%% You should have received a copy of the GNU General Public
+%% License along with this software; see the file COPYING.
+%% If not, see <http://www.gnu.org/licenses/>.
+
+%% -*- texinfo -*-
+%% @documentencoding UTF-8
+%% @defmethod @@sym ellipticK (@var{m})
+%% Complete elliptic integral of the first kind.
+%%
+%% Example:
+%% @example
+%% @group
+%% syms m
+%% ellipticK (m)
+%%   @result{} ans = (sym) K(m)
+%% @end group
+%%
+%% @group
+%% rewrite (ans, 'Integral')         % doctest: +SKIP
+%%   @result{} ans = (sym)
+%%       π
+%%       ─
+%%       2
+%%       ⌠
+%%       ⎮          1
+%%       ⎮ ──────────────────── dα
+%%       ⎮    _________________
+%%       ⎮   ╱        2
+%%       ⎮ ╲╱  - m⋅sin (α) + 1
+%%       ⌡
+%%       0
+%% @end group
+%%
+%% @group
+%% double (ellipticK (sym (pi)/4))
+%%   @result{} ans =  2.2253
+%% @end group
+%% @end example
+%%
+%% @seealso{@@sym/ellipticF, @@sym/ellipticPi, ellipKE}
+%% @end defmethod
+
+
+function y = ellipticK(m)
+  if nargin > 1
+    print_usage();
+  end
+
+% y = ellipticF (sym (pi)/2, m);
+  y = elementwise_op ('elliptic_k', m);
+
+end
+
+
+%!assert (isequal (ellipticK (sym (0)), sym (pi)/2))
+%!assert (isequal (ellipticK (sym (-inf)), sym (0)))
+
+%!assert (double (ellipticK (sym (1)/2)), 1.854074677, 10e-10)
+%!assert (double (ellipticK (sym (pi)/4)), 2.225253684, 10e-10)
+%!assert (double (ellipticK (sym (-55)/10)), 0.9324665884, 10e-11)
+
+%!test
+%! % compare to double ellipke
+%! m = 1/5;
+%! ms = sym(1)/5;
+%! [K, E] = ellipke (m);
+%! assert (double (ellipticK (ms)), K, -1e-15)
+%! assert (double (ellipticE (ms)), E, -1e-15)
+
+%!test
+%! % compare to double ellipke
+%! m = -10.3;
+%! ms = -sym(103)/10;
+%! [K, E] = ellipke (m);
+%! assert (double (ellipticK (ms)), K, -1e-15)
+%! assert (double (ellipticE (ms)), E, -1e-15)

--- a/inst/@sym/ellipticPi.m
+++ b/inst/@sym/ellipticPi.m
@@ -1,0 +1,99 @@
+%% Copyright (C) 2016 Lagu
+%%
+%% This file is part of OctSymPy.
+%%
+%% OctSymPy is free software; you can redistribute it and/or modify
+%% it under the terms of the GNU General Public License as published
+%% by the Free Software Foundation; either version 3 of the License,
+%% or (at your option) any later version.
+%%
+%% This software is distributed in the hope that it will be useful,
+%% but WITHOUT ANY WARRANTY; without even the implied warranty
+%% of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See
+%% the GNU General Public License for more details.
+%%
+%% You should have received a copy of the GNU General Public
+%% License along with this software; see the file COPYING.
+%% If not, see <http://www.gnu.org/licenses/>.
+
+%% -*- texinfo -*-
+%% @documentencoding UTF-8
+%% @defmethod @@sym y = ellipticPi (@var{n}, @var{m})
+%% @defmethodx @@sym y = ellipticPi (@var{n}, @var{phi}, @var{m})
+%% Complete and incomplete elliptic integrals of the third kind.
+%%
+%% Incomplete elliptic integral of the third kind:
+%% @example
+%% @group
+%% syms n phi m
+%% ellipticPi (n, phi, m)
+%% @end group
+%%
+%% @group
+%% rewrite (ans, 'Integral')         % doctest: +SKIP
+%%   @result{} ans = (sym)
+%%       φ
+%%       ⌠
+%%       ⎮                   1
+%%       ⎮ ────────────────────────────────────── dα
+%%       ⎮    _________________
+%%       ⎮   ╱        2         ⎛       2       ⎞
+%%       ⎮ ╲╱  - m⋅sin (α) + 1 ⋅⎝- n⋅sin (α) + 1⎠
+%%       ⌡
+%%       0
+%% @end group
+%% @group
+%% double (ellipticPi (sym (1), sym (1)/10, sym (1)/2))
+%%   @result{} ans =  0.10042
+%% @end group
+%% @end example
+%% Complete elliptic integral of the third kind:
+%% @example
+%% @group
+%% syms n m
+%% ellipticPi (n, m)
+%%   @result{} ans = (sym) Π(n│m)
+%% @end group
+%%
+%% @group
+%% rewrite (ans, 'Integral')         % doctest: +SKIP
+%%   @result{} ans = (sym)
+%%       π
+%%       ─
+%%       2
+%%       ⌠
+%%       ⎮                   1
+%%       ⎮ ────────────────────────────────────── dα
+%%       ⎮    _________________
+%%       ⎮   ╱        2         ⎛       2       ⎞
+%%       ⎮ ╲╱  - m⋅sin (α) + 1 ⋅⎝- n⋅sin (α) + 1⎠
+%%       ⌡
+%%       0
+%% @end group
+%% @group
+%% double (ellipticPi (sym (pi)/4, sym (pi)/8))
+%%   @result{} ans =  4.0068
+%% @end group
+%% @end example
+%%
+%% @end defmethod
+
+
+function y = ellipticPi(n, phi, m)
+
+  switch nargin
+    case 2
+      y = ellipticPi (n, sym (pi)/2, phi);
+    case 3
+      y = elementwise_op ('elliptic_pi', sym (n), sym (phi), sym (m));
+    otherwise
+      print_usage();
+  end
+
+end
+
+
+%!assert (double (ellipticPi (sym (-23)/10, sym (pi)/4, 0)), 0.5876852228, 10e-11)
+%!assert (double (ellipticPi (sym (1)/3, sym (pi)/3, sym (1)/2)), 1.285032276, 10e-11)
+%!xtest assert (double (ellipticPi (sym (-1), 0, sym (1))), 0)
+%!assert (double (ellipticPi (sym (2), sym (pi)/6, sym (2))), 0.7507322117, 10e-11)


### PR DESCRIPTION
Hi!, now the elliptic functions.

As you can see some functions have less or more tests, this is because some approximations of SMT don't match with Sympy, and checking don't match with WolframAlpha too, take in consideration the approximations of Sympy are too close to WolframAlpha, so in that cases i use less tests.

Little example:
EllipticCPi(-1, 1/3)
  WA:      1.205059303480956918275419123818767032685642224169380264249...
  Sympy: 1.205059303480956918275419123818767032685642224169380264249...
  SMT:     1.370337322....

you can use this commands directly in this platforms.

Thx. Cya.