### PR TITLE
char: gives human-readable string not sympy srepr

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -58,6 +58,9 @@ octsympy 2.5.0-dev
 
   * Bug fix: assign `[]` to row/column removes that that row/column.
 
+  * `char(x)` now gives a more-human readable output, useful for example
+    in labelling a figure.
+
 
 
 octsympy 2.4.1-dev

--- a/inst/@sym/char.m
+++ b/inst/@sym/char.m
@@ -19,25 +19,56 @@
 %% -*- texinfo -*-
 %% @documentencoding UTF-8
 %% @defmethod @@sym char (@var{x})
-%% Return underlying string representation of a symbolic expression.
+%% Return string representation of a symbolic expression.
 %%
-%% Although not intended for general use, the underlying SymPy string
-%% representation (“srepr”) can be recovered with this command:
+%% Example:
 %% @example
 %% @group
-%% syms x positive
-%% srepr = char (x)
-%%   @result{} srepr = Symbol('x', positive=True)
+%% f = [sym(pi)/2 ceil(sym('x')/3); sym('alpha') sym(3)/2]
+%%   @result{} f = (sym 2×2 matrix)
+%%
+%%       ⎡π  ⎡x⎤⎤
+%%       ⎢─  ⎢─⎥⎥
+%%       ⎢2  ⎢3⎥⎥
+%%       ⎢      ⎥
+%%       ⎣α  3/2⎦
+%%
+%% char(f)
+%%   @result{} Matrix([[pi/2, ceiling(x/3)], [alpha, 3/2]])
 %% @end group
 %% @end example
 %%
-%% It can then be passed directly to sym:
+%% This command generally gives a human-readable string but it may not be
+%% sufficient for perfect reconstruction of the symbolic expression.
+%% For example @code{char(x)} does not display assumptions:
 %% @example
 %% @group
-%% x2 = sym (srepr)
-%%   @result{} x2 = (sym) x
-%% x2 == x
-%%   @result{} (sym) True
+%% syms x positive
+%% char (x)
+%%   @result{} x
+%% @end group
+%% @end example
+%% And because of this, passing the output of @code{char} to @code{sym}
+%% loses information:
+%% @example
+%% @group
+%% x2 = sym (char (x));
+%%
+%% assumptions (x2)
+%%   @result{} ans =
+%%       @{@}(0x0)
+%% @end group
+%% @end example
+%%
+%%
+%% if you need a more precise
+%% string representation of a symbolic object, the underlying SymPy string
+%% representation (“srepr”) can be recovered, although this is not supported or
+%% intended for general use:
+%% @example
+%% @group
+%% x.pickle
+%%   @result{} ans = Symbol('x', positive=True)
 %% @end group
 %% @end example
 %%
@@ -47,13 +78,20 @@
 
 function s = char(x)
 
-  s = x.pickle;
+  s = x.flat;
 
 end
 
 
 %!test
 %! % issue #91: expose as string
-%! syms x
-%! s = char(x);
-%! assert (strcmp (s, 'Symbol(''x'')'))
+%! a = sym(pi);
+%! assert (strcmp (char (a), 'pi'))
+
+%!shared x
+%! x = sym('x');
+
+%!assert (strcmp (char (x), 'x'))
+%!assert (strcmp (char (2*x), '2*x'))
+%!assert (strcmp (char ([2*x x]), 'Matrix([[2*x, x]])'))
+%!assert (strcmp (char ([2*x 2; 1 x]), 'Matrix([[2*x, 2], [1, x]])'))

--- a/inst/@sym/display.m
+++ b/inst/@sym/display.m
@@ -159,7 +159,7 @@ function [s1 s2] = sym_describe(x, unicode_dec)
   end
 
   s1 = class (x);
-  srepr = char (x);
+  srepr = x.pickle;
   d = size (x);
 
   % sort of isinstance(x, MatrixExpr) but cheaper
@@ -215,7 +215,7 @@ function snip = snippet_of_sympy(x, padw, width, unicode)
   pad = repmat(' ', 1, padw);
 
   % trim newlines (if there are any)
-  s = regexprep (char (x), '\n', '\\n');
+  s = regexprep (x.pickle, '\n', '\\n');
   snip = [pad lquot s rquot];
   if (ustr_length (snip) > width)
     n = width - rightpad - padw - ustr_length ([lquot rquot ell]);

--- a/inst/@sym/mrdivide.m
+++ b/inst/@sym/mrdivide.m
@@ -107,7 +107,7 @@ end
 %! % I/A: either invert A or leave unevaluated: not bothered which
 %! A = sym([1 2; 3 4]);
 %! B = sym(eye(2)) / A;
-%! assert (isequal (B, inv(A))  ||  strncmpi(char(B), 'MatPow', 6))
+%! assert (isequal (B, inv(A))  ||  strncmpi (B.pickle, 'MatPow', 6))
 
 %!test
 %! % A = C/B is C = A*B

--- a/inst/@sym/not.m
+++ b/inst/@sym/not.m
@@ -93,7 +93,7 @@ end
 %! syms x
 %! e = ~(x == 4);
 %! assert (isa (e, 'sym'))
-%! assert (strncmp(char(e), 'Unequality', 10))
+%! assert (strncmp (e.pickle, 'Unequality', 10))
 
 %!test
 %! % output is sym even for scalar t/f (should match other bool fcns)

--- a/inst/@sym/sym.m
+++ b/inst/@sym/sym.m
@@ -150,7 +150,7 @@
 %% needed in the usual way with the @code{save} and @code{load} commands.
 %%
 %% The underlying SymPy string representation (``srepr'') can also be passed
-%% directly to @code{sym}: @pxref{@@sym/char} for details.
+%% directly to @code{sym}: @pxref{@@sym/char} for discussion of the details.
 %%
 %% @seealso{syms, assumptions, @@sym/assume, @@sym/assumeAlso}
 %% @end deftypeop
@@ -643,8 +643,8 @@ end
 %!test
 %! % symbols with special sympy names
 %! syms Ei Eq
-%! assert (~isempty(regexp(char(Eq), '^Symbol')))
-%! assert (~isempty(regexp(char(Ei), '^Symbol')))
+%! assert (~isempty(regexp(Eq.pickle, '^Symbol')))
+%! assert (~isempty(regexp(Ei.pickle, '^Symbol')))
 
 %!test
 %! % E can be a sym not just exp(sym(1))

--- a/inst/@symfun/symvar.m
+++ b/inst/@symfun/symvar.m
@@ -129,7 +129,7 @@ function a = remove_dupes(symvars, vars)
   keep = logical(ones(1, length(symvars)));
   for j = 1:length(symvars)
     for i = 1:M
-      if (strcmp(char(symvars(j)), char(vars(i))))
+      if (strcmp (symvars(j).pickle, vars(i).pickle))
         keep(j) = false;
         break
       end

--- a/inst/@symfun/symvar.m
+++ b/inst/@symfun/symvar.m
@@ -129,7 +129,9 @@ function a = remove_dupes(symvars, vars)
   keep = logical(ones(1, length(symvars)));
   for j = 1:length(symvars)
     for i = 1:M
-      if (strcmp (symvars(j).pickle, vars(i).pickle))
+      A = symvars(j);
+      B = vars(i);
+      if (strcmp (A.pickle, B.pickle))
         keep(j) = false;
         break
       end

--- a/inst/assumptions.m
+++ b/inst/assumptions.m
@@ -189,7 +189,7 @@ end
 %!   x = sym('x', A{i});
 %!   a = assumptions(x);
 %!   assert(strcmp(a{1}, ['x: ' A{i}] ))
-%!   s1 = char(x);
+%!   s1 = x.pickle;
 %!   s2 = ['Symbol(''x'', ' A{i} '=True)'];
 %!   assert (strcmp (s1, s2))
 %! end

--- a/inst/findsymbols.m
+++ b/inst/findsymbols.m
@@ -101,7 +101,7 @@ function L = findsymbols(obj, dosort)
   if dosort
     Ls = {};
     for i=1:length(L)
-      Ls{i} = char(L{i});
+      Ls{i} = L{i}.pickle;
     end
     [tilde, I] = unique(Ls);
     L = L(I);

--- a/inst/private/check_and_convert.m
+++ b/inst/private/check_and_convert.m
@@ -48,7 +48,7 @@ function obj = check_and_convert(var_pyobj)
     elseif (py.isinstance(x, list_or_tuple))
       obj{i} = check_and_convert(x);
     elseif (py.isinstance (x, string_types))
-      obj{i} = char (x);
+      obj{i} = x.pickle;
     elseif (py.isinstance(x, builtins.dict))
       make_str_keys = pyeval ('lambda x: {str(k): v for k, v in x.items()}');
       x = pycall (make_str_keys, x);

--- a/inst/private/python_copy_vars_to.m
+++ b/inst/private/python_copy_vars_to.m
@@ -52,8 +52,8 @@ function a = do_list(indent, in, varlist)
       % .append(pickle.loads("""%s"""))', x.pickle)
       % The extra printf around the pickle helps if it still has
       % escape codes (and seems harmless if it does not)
-      % Issue #107: x.pickle fails for matrices, use char() as workaround
-      c=c+1; a{c} = sprintf('%s%s.append(%s)', sp, in, sprintf(char(x)));
+      % Issue #107: .pickle may fail for matrices on Matlab
+      c=c+1; a{c} = sprintf('%s%s.append(%s)', sp, in, sprintf(x.pickle));
 
     elseif (ischar(x))
       if (exist ('OCTAVE_VERSION', 'builtin'))

--- a/inst/private/store_vars_in_python.m
+++ b/inst/private/store_vars_in_python.m
@@ -22,7 +22,7 @@ function var_pyobj = store_vars_in_python (L)
   for i = 1:numel(L)
     x = L{i};
     if (isa(x, 'sym'))
-      var_pyobj.append(pyeval(char(x)))
+      var_pyobj.append (pyeval (x.pickle))
     elseif (iscell (x))
       var_pyobj.append (store_vars_in_python (x))
     else

--- a/inst/vpa.m
+++ b/inst/vpa.m
@@ -219,8 +219,8 @@ end
 %! % these should *not* be the same
 %! a = vpa(2.3, 40);
 %! b = vpa('2.3', 40);
-%! sa = char(a);
-%! sb = char(b);
+%! sa = a.pickle;
+%! sb = b.pickle;
 %! assert (~isequal (a, b))
 %! assert (abs(double(a - b)) > 1e-20)
 %! assert (abs(double(a - b)) < 1e-15)


### PR DESCRIPTION
This is more useful, e.g., for labelling a plot and I think its
what people would expect to happen if they cast a object to char.
It does mean that `sym(char(x))` doesn't always reproduce `x` with
the fidelity that it used too because previously `x` gave the
implementation (srepr) of the object.  That change is documented in
char.m.

Fixes #375, also effects (or affects) #91.