### PR TITLE
Fix subsasgn behaviour when logical indices are used.

### DIFF
--- a/inst/@sym/private/mat_replace.m
+++ b/inst/@sym/private/mat_replace.m
@@ -1,5 +1,6 @@
 %% Copyright (C) 2014-2016 Colin B. Macdonald
 %% Copyright (C) 2016 Lagu
+%% Copyright (C) 2016 Abhinav Tripathi
 %%
 %% This file is part of OctSymPy.
 %%
@@ -28,6 +29,18 @@
 
 function z = mat_replace(A, subs, b)
 
+  if (length (subs) == 1 && islogical (subs{1}))
+    %% A(logical) = B
+    subs{1} = find (subs{1});
+    if isempty (subs{1})
+      z = A;
+      return;
+    end
+    if (~ isscalar (b) && ~ isvector (b) && ~ isempty (b))
+      warning ('OctSymPy:subsagn:rhs_shape', ...
+            'B neither vector nor scalar in indexed A(I)=B: unusual, did you intend this?')
+    end
+  end
   %% Check when b is []
   if (isempty(b))
     switch length(subs)
@@ -66,12 +79,7 @@ function z = mat_replace(A, subs, b)
     end
   end
 
-  if (length(subs) == 1 && islogical(subs{1}))
-    %% A(logical) = B
-    z = mat_mask_asgn(A, subs{1}, b);
-    return
-
-  elseif (length(subs) == 1 && strcmp(subs{1}, ':') && length(b) == 1)
+  if (length(subs) == 1 && strcmp(subs{1}, ':') && length(b) == 1)
     z = python_cmd('return ones(_ins[0], _ins[1])*_ins[2],', A.size(1), A.size(2), sym(b));
     return
 

--- a/inst/@sym/private/mat_replace.m
+++ b/inst/@sym/private/mat_replace.m
@@ -94,6 +94,9 @@ function z = mat_replace(A, subs, b)
     else
       % linear indices into 2D array
       [r, c] = ind2sub (size(A), subs{1});
+      % keep all the indices in a row vector
+      r = reshape (r, 1, []);
+      c = reshape (c, 1, []);
     end
 
   elseif (length(subs) == 2)

--- a/inst/@sym/subsasgn.m
+++ b/inst/@sym/subsasgn.m
@@ -522,6 +522,14 @@ end
 %% Tests from mat_replace
 
 %!test
+%! % 2D indexing with length in one dimension more than 2
+%! a = sym ([1 2; 3 4; 5 6]);
+%! indices = [1 4; 2 5; 3 6];
+%! b = [10 11; 12 13; 14 15];
+%! a(indices) = b;
+%! assert (isequal (a, sym (b)));
+
+%!test
 %! A = sym ([0 0 0]);
 %! indices = [false true false];
 %! A(indices) = 1;

--- a/inst/@sym/subsasgn.m
+++ b/inst/@sym/subsasgn.m
@@ -1,5 +1,6 @@
 %% Copyright (C) 2014-2016 Colin B. Macdonald
 %% Copyright (C) 2016 Lagu
+%% Copyright (C) 2016 Abhinav Tripathi
 %%
 %% This file is part of OctSymPy.
 %%
@@ -516,5 +517,64 @@ end
 %!error <null assignment>
 %! a = sym([1, 2; 3, 4]);
 %! a(1, 2) = [];
+
+
+%% Tests from mat_replace
+
+%!test
+%! A = sym ([0 0 0]);
+%! indices = [false true false];
+%! A(indices) = 1;
+%! assert (isequal (A, sym ([0 1 0])));
+%! A(indices) = [];
+%! assert (isequal (A, sym ([0 0])));
+%! indices = [false false];
+%! A(indices) = [];
+%! assert (isequal (A, sym ([0 0])));
+
+%!shared a, b
+%! a = [1 2 3 5; 4 5 6 9; 7 5 3 2];
+%! b = sym (a);
+
+%!function test_bool (a, b, c)
+%!  a(c) = 0;
+%!  b(c) = 0;
+%!  assert (isequal (a, b))
+%!endfunction
+
+%!test
+%! c = false;
+%! test_bool (a, b, c)
+%! test_bool (a, b, c | true)
+
+%!test
+%! c = [false true];
+%! test_bool (a, b, c)
+%! test_bool (a, b, c | true)
+%! test_bool (a, b, c & false)
+
+%!test
+%! c = [false true false true; true false true false; false true false true];
+%! test_bool (a, b, c)
+%! test_bool (a, b, c | true)
+%! test_bool (a, b, c & false)
+
+%!test
+%! c = [false true false true false];
+%! test_bool (a, b, c)
+%! test_bool (a, b, c | true)
+%! test_bool (a, b, c & false)
+
+%!test
+%! c = [false; true; false; true; false];
+%! test_bool (a, b, c)
+%! test_bool (a, b, c | true)
+%! test_bool (a, b, c & false)
+
+%!test
+%! c = [false true; false true; true false];
+%! test_bool (a, b, c)
+%! test_bool (a, b, c | true)
+%! test_bool (a, b, c & false)
 
 %% End of mat_* tests


### PR DESCRIPTION
Fixes issue #598
When logical indices are used, pass the valid indices (if any). If there are
no valid indices then return the input as is.