### PR TITLE
Makefile changes

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-SHELL   = /bin/bash
+SHELL   := /bin/bash
 
 ## Copyright 2016 Colin B. Macdonald
 ##
@@ -7,16 +7,16 @@ SHELL   = /bin/bash
 ## notice and this notice are preserved.  This file is offered as-is,
 ## without any warranty.
 
-PACKAGE = $(shell grep "^Name: " DESCRIPTION | cut -f2 -d" ")
-VERSION = $(shell grep "^Version: " DESCRIPTION | cut -f2 -d" ")
-MATLAB_PACKAGE = octsympy
-BUILD_DIR = tmp
-MATLAB_PKG_DIR=${MATLAB_PACKAGE}-matlab-${VERSION}
-OCTAVE_RELEASE_TARBALL = ${BUILD_DIR}/${PACKAGE}-${VERSION}.tar
-OCTAVE_RELEASE_TARBALL_COMPRESSED = ${OCTAVE_RELEASE_TARBALL}.gz
-INSTALLED_PACKAGE = ~/octave/${PACKAGE}-${VERSION}/packinfo/DESCRIPTION
-HTML_DIR = ${BUILD_DIR}/${PACKAGE}-html
-HTML_TARBALL_COMPRESSED = ${HTML_DIR}.tar.gz
+PACKAGE := $(shell grep "^Name: " DESCRIPTION | cut -f2 -d" ")
+VERSION := $(shell grep "^Version: " DESCRIPTION | cut -f2 -d" ")
+MATLAB_PACKAGE := octsympy
+BUILD_DIR := tmp
+MATLAB_PKG_DIR := ${MATLAB_PACKAGE}-matlab-${VERSION}
+OCTAVE_RELEASE_TARBALL := ${BUILD_DIR}/${PACKAGE}-${VERSION}.tar
+OCTAVE_RELEASE_TARBALL_COMPRESSED := ${OCTAVE_RELEASE_TARBALL}.gz
+INSTALLED_PACKAGE := ~/octave/${PACKAGE}-${VERSION}/packinfo/DESCRIPTION
+HTML_DIR := ${BUILD_DIR}/${PACKAGE}-html
+HTML_TARBALL_COMPRESSED := ${HTML_DIR}.tar.gz
 
 OCTAVE ?= octave
 MATLAB ?= matlab

--- a/Makefile
+++ b/Makefile
@@ -15,6 +15,7 @@ BUILD_DIR := tmp
 MATLAB_PKG_DIR := ${MATLAB_PACKAGE}-matlab-${VERSION}
 OCTAVE_RELEASE := ${BUILD_DIR}/${PACKAGE}-${VERSION}
 OCTAVE_RELEASE_TARBALL := ${BUILD_DIR}/${PACKAGE}-${VERSION}.tar.gz
+OCTAVE_RELEASE_ZIP := ${BUILD_DIR}/${PACKAGE}-${VERSION}.zip
 
 INSTALLED_PACKAGE := ~/octave/${PACKAGE}-${VERSION}/packinfo/DESCRIPTION
 HTML_DIR := ${BUILD_DIR}/${PACKAGE}-html
@@ -39,6 +40,9 @@ help:
 
 %.tar.gz: %
 	tar -c -f - --posix -C "$(BUILD_DIR)/" "$(notdir $<)" | gzip -9n > "$@"
+
+%.zip: %
+	cd "$(BUILD_DIR)" ; zip -9qr - "$(notdir $<)" > "$(notdir $@)"
 
 $(OCTAVE_RELEASE): .git/index | $(BUILD_DIR)
 	@echo "Creating package version $(VERSION) release ..."
@@ -67,6 +71,7 @@ $(HTML_DIR): install | $(BUILD_DIR)
 	chmod -R a+rX,u+w,go-w $@
 
 dist: $(OCTAVE_RELEASE_TARBALL)
+zip: $(OCTAVE_RELEASE_ZIP)
 html: $(HTML_TARBALL)
 
 ${BUILD_DIR} ${BUILD_DIR}/${MATLAB_PKG_DIR}/private ${BUILD_DIR}/${MATLAB_PKG_DIR}/tests_matlab ${BUILD_DIR}/${MATLAB_PKG_DIR}/@sym ${BUILD_DIR}/${MATLAB_PKG_DIR}/@symfun ${BUILD_DIR}/${MATLAB_PKG_DIR}/@logical:
@@ -104,8 +109,6 @@ doctest:
 install: ${INSTALLED_PACKAGE}
 ${INSTALLED_PACKAGE}: ${OCTAVE_RELEASE_TARBALL_COMPRESSED}
 	$(OCTAVE) --silent --eval "pkg install $<"
-
-## TODO: make zip file
 
 ## Matlab packaging
 matlab_pkg: ${BUILD_DIR}/${MATLAB_PKG_DIR}/private ml_extract_tests


### PR DESCRIPTION
Main changes:

* use `:=` instead of `=` which does [lazy assignment](http://stackoverflow.com/a/448939/1609556)
* `make dist` instead of `make pkg` so it matches what other packages are doing (see [proposal](https://lists.gnu.org/archive/html/octave-maintainers/2016-11/msg00065.html) to make this target a requirement for for packages)
* the changed recipe for Octave package release and html is mostly to match the code from the other packages so that they all work in similar way which makes it easier when copying other recipes from other Makefiles of Octave Forge.