### PR TITLE
sympref: show argument value in error message

### DIFF
--- a/inst/sympref.m
+++ b/inst/sympref.m
@@ -316,7 +316,7 @@ function varargout = sympref(cmd, arg)
       %pkg_path = pkg_l{idx}.dir
 
     otherwise
-      print_usage ();
+      error ('sympref: invalid preference or command ''%s''', lower (cmd));
   end
 end
 
@@ -421,3 +421,6 @@ end
 %! sympref ('quiet', sympref_orig.quiet);
 %! syms x
 %! assert(r)
+
+%!error <invalid preference or command> sympref ('nosuchsetting')
+%!error <invalid preference or command> sympref ('nosuchsetting', true)


### PR DESCRIPTION
Show a more explicit error message with the unrecognized argument value.

This looks more helpful to me than the standard "usage" message. In Octave we typically reserve `print_usage` for when the number or types of arguments are blatantly wrong, but not when the value is out of range or an unrecognized string enum like this function.