### PR TITLE
sympref: add support to restore settings from a structure (issue #668)

### DIFF
--- a/inst/sympref.m
+++ b/inst/sympref.m
@@ -183,6 +183,21 @@ function varargout = sympref(cmd, arg)
     return
   end
 
+  if (isstruct (cmd))
+    % Means we need to copy it
+    s = sympref();
+
+    assert (isequal (fieldnames (s)', ...
+      {'ipc', 'whichpython', 'display', 'digits', 'quiet'}), ...
+      'sympref: Type of fields of the structure is not correct')
+    settings = [];
+    sympref ('ipc', cmd.ipc)
+    settings.whichpython = cmd.whichpython;
+    sympref ('display', cmd.display)
+    sympref ('digits', cmd.digits)
+    sympref ('quiet', cmd.quiet)
+    return
+  end
 
   switch lower(cmd)
     case 'defaults'
@@ -424,3 +439,12 @@ end
 
 %!error <invalid preference or command> sympref ('nosuchsetting')
 %!error <invalid preference or command> sympref ('nosuchsetting', true)
+
+%!test
+%! syms x
+%! old = sympref();
+%! sympref ('display', 'ascii');
+%! sympref ('digits', 64);
+%! sympref (old);
+%! new = sympref();
+%! assert(isequal(old, new))

--- a/inst/sympref.m
+++ b/inst/sympref.m
@@ -1,4 +1,5 @@
 %% Copyright (C) 2014-2016 Colin B. Macdonald
+%% Copyright (C) 2017 NVS Abhilash
 %%
 %% This file is part of OctSymPy.
 %%
@@ -184,18 +185,15 @@ function varargout = sympref(cmd, arg)
   end
 
   if (isstruct (cmd))
-    % Means we need to copy it
-    s = sympref();
-
-    assert (isequal (fieldnames (s)', ...
+    assert (isequal (fieldnames (cmd)', ...
       {'ipc', 'whichpython', 'display', 'digits', 'quiet'}), ...
       'sympref: Type of fields of the structure is not correct')
     settings = [];
-    sympref ('ipc', cmd.ipc)
+    sympref ('quiet', cmd.quiet)
     settings.whichpython = cmd.whichpython;
     sympref ('display', cmd.display)
     sympref ('digits', cmd.digits)
-    sympref ('quiet', cmd.quiet)
+    sympref ('ipc', cmd.ipc)
     return
   end
 
@@ -429,6 +427,19 @@ end
 %! sympref('quiet', 'on')
 
 %!test
+%! old = sympref ();
+%! sympref ('display', 'ascii');
+%! sympref ('digits', 64);
+%! sympref (old);
+%! new = sympref ();
+%! assert (isequal (old, new))
+
+%!test
+%! s.a = "hello";
+%! s.b = "world";
+%!error sympref(s)
+
+%!test
 %! syms x
 %! r = sympref('reset');
 %! % restore original sympref settings
@@ -439,12 +450,3 @@ end
 
 %!error <invalid preference or command> sympref ('nosuchsetting')
 %!error <invalid preference or command> sympref ('nosuchsetting', true)
-
-%!test
-%! syms x
-%! old = sympref();
-%! sympref ('display', 'ascii');
-%! sympref ('digits', 64);
-%! sympref (old);
-%! new = sympref();
-%! assert(isequal(old, new))

--- a/inst/sympref.m
+++ b/inst/sympref.m
@@ -187,7 +187,7 @@ function varargout = sympref(cmd, arg)
   if (isstruct (cmd))
     assert (isequal (fieldnames (cmd)', ...
       {'ipc', 'whichpython', 'display', 'digits', 'quiet'}), ...
-      'sympref: Type of fields of the structure is not correct')
+      'sympref: fields of the structure is not correct')
     settings = [];
     sympref ('quiet', cmd.quiet)
     settings.whichpython = cmd.whichpython;

--- a/inst/sympref.m
+++ b/inst/sympref.m
@@ -187,7 +187,7 @@ function varargout = sympref(cmd, arg)
   if (isstruct (cmd))
     assert (isequal (fieldnames (cmd)', ...
       {'ipc', 'whichpython', 'display', 'digits', 'quiet'}), ...
-      'sympref: fields of the structure is not correct')
+      'sympref: structure has incorrect field names')
     settings = [];
     sympref ('quiet', cmd.quiet)
     settings.whichpython = cmd.whichpython;
@@ -434,10 +434,10 @@ end
 %! new = sympref ();
 %! assert (isequal (old, new))
 
-%!test
-%! s.a = "hello";
-%! s.b = "world";
-%!error sympref(s)
+%!error <incorrect field names>
+%! s.a = 'hello';
+%! s.b = 'world';
+%! sympref (s)
 
 %!test
 %! syms x

--- a/inst/sympref.m
+++ b/inst/sympref.m
@@ -185,8 +185,8 @@ function varargout = sympref(cmd, arg)
   end
 
   if (isstruct (cmd))
-    assert (isequal (fieldnames (cmd)', ...
-      {'ipc', 'whichpython', 'display', 'digits', 'quiet'}), ...
+    assert (isequal (sort (fieldnames (cmd)), ...
+      sort ({'ipc'; 'whichpython'; 'display'; 'digits'; 'quiet'})), ...
       'sympref: structure has incorrect field names')
     settings = [];
     sympref ('quiet', cmd.quiet)
@@ -427,9 +427,11 @@ end
 %! sympref('quiet', 'on')
 
 %!test
+%! % restore sympref from structure
 %! old = sympref ();
 %! sympref ('display', 'ascii');
 %! sympref ('digits', 64);
+%! old = orderfields (old);  % re-ordering the fields should be ok
 %! sympref (old);
 %! new = sympref ();
 %! assert (isequal (old, new))


### PR DESCRIPTION
This is a rebase of the work in #717, and a few minor fixes.

@nvs-abhilash I basically just squashed the first two commits (for a cleaner commit history and changes a few commit messages).
