### PR TITLE
sym constructor: add deprecation warning for sym(cell)

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -36,6 +36,9 @@ octsympy 2.5.0-dev
           fresnelc      sinint
           fresnels      zeta
 
+  * Deprecation notice: `sym(cell)` will soon create a sym array
+    (currently it creates a cell array of sym objects.)
+
   * The full set of assumptions implemented by Sympy can now be used.
     For example, `syms p prime` assumes `p` is prime.
 

--- a/inst/@sym/charpoly.m
+++ b/inst/@sym/charpoly.m
@@ -1,4 +1,5 @@
 %% Copyright (C) 2016 Lagu
+%% Copyright (C) 2017 Colin B. Macdonald
 %%
 %% This file is part of OctSymPy.
 %%
@@ -91,7 +92,10 @@ function y = charpoly(varargin)
          'else:'
          '    return _ins[0].charpoly(_ins[1]).as_expr(),'};
 
-  y = python_cmd(cmd , sym(varargin){:});
+  for i = 1:nargin
+    varargin{i} = sym(varargin{i});
+  end
+  y = python_cmd(cmd, varargin{:});
 
   if (nargin == 1)
     y = cell2sym(y);

--- a/inst/@sym/diff.m
+++ b/inst/@sym/diff.m
@@ -1,4 +1,4 @@
-%% Copyright (C) 2014-2016 Colin B. Macdonald
+%% Copyright (C) 2014-2017 Colin B. Macdonald
 %%
 %% This file is part of OctSymPy.
 %%
@@ -104,7 +104,9 @@ function z = diff(f, varargin)
           'args = _ins[1:]'
           'return f.diff(*args),' };
 
-  varargin = sym(varargin);
+  for i = 1:length(varargin)
+    varargin{i} = sym(varargin{i});
+  end
   z = python_cmd (cmd, sym(f), varargin{:});
 
 end

--- a/inst/@sym/eye.m
+++ b/inst/@sym/eye.m
@@ -55,14 +55,19 @@ function y = eye(varargin)
     return
   end
 
-  if nargin > 1 %%Sympy don't support eye(A, B)
-    y = sym(eye (cell2nosyms (varargin){:}));
-  else
-    for i = 1:length(varargin)
-      varargin{i} = sym(varargin{i});
-    end
-    y = python_cmd ('return eye(*_ins)', varargin{:});
+  for i = 1:length(varargin)
+    varargin{i} = sym(varargin{i});
   end
+
+  if nargin == 1
+    cmd = 'return eye(*_ins)';
+  else
+    %% Sympy don't support eye(A, B)
+    cmd = { 'n, m = _ins'
+            'return eye(max(n,m))[0:n,0:m]' };
+  end
+
+  y = python_cmd (cmd, varargin{:});
 
 end
 

--- a/inst/@sym/eye.m
+++ b/inst/@sym/eye.m
@@ -1,4 +1,5 @@
 %% Copyright (C) 2016 Lagu
+%% Copyright (C) 2017 Colin B. Macdonald
 %%
 %% This file is part of OctSymPy.
 %%
@@ -57,7 +58,10 @@ function y = eye(varargin)
   if nargin > 1 %%Sympy don't support eye(A, B)
     y = sym(eye (cell2nosyms (varargin){:}));
   else
-    y = python_cmd ('return eye(*_ins)', sym(varargin){:});
+    for i = 1:length(varargin)
+      varargin{i} = sym(varargin{i});
+    end
+    y = python_cmd ('return eye(*_ins)', varargin{:});
   end
 
 end

--- a/inst/@sym/factor.m
+++ b/inst/@sym/factor.m
@@ -98,7 +98,9 @@
 function [p, m] = factor(f, varargin)
 
   f = sym(f);
-  varargin = sym(varargin);
+  for i = 1:length(varargin)
+    varargin{i} = sym(varargin{i});
+  end
 
   if ((nargin > 1) || (~isempty (findsymbols (f))))
     %% have symbols, do polynomial factorization

--- a/inst/@sym/horzcat.m
+++ b/inst/@sym/horzcat.m
@@ -1,4 +1,4 @@
-%% Copyright (C) 2014-2016 Colin B. Macdonald
+%% Copyright (C) 2014-2017 Colin B. Macdonald
 %%
 %% This file is part of OctSymPy.
 %%
@@ -60,7 +60,9 @@ function h = horzcat(varargin)
           'return sp.MatrixBase.hstack(*_proc),'
           };
 
-  varargin = sym(varargin);
+  for i = 1:nargin
+    varargin{i} = sym(varargin{i});
+  end
   h = python_cmd (cmd, varargin{:});
 
 end

--- a/inst/@sym/interval.m
+++ b/inst/@sym/interval.m
@@ -1,4 +1,4 @@
-%% Copyright (C) 2016 Colin B. Macdonald
+%% Copyright (C) 2016-2017 Colin B. Macdonald
 %% Copyright (C) 2016 Lagu
 %%
 %% This file is part of OctSymPy.
@@ -56,7 +56,9 @@ function I = interval(varargin)
     print_usage();
   end
 
-  varargin = sym(varargin);
+  for i = 1:nargin
+    varargin{i} = sym(varargin{i});
+  end
 
   I = python_cmd ('return Interval(*_ins),', varargin{:});
 

--- a/inst/@sym/ones.m
+++ b/inst/@sym/ones.m
@@ -1,4 +1,5 @@
 %% Copyright (C) 2016 Lagu
+%% Copyright (C) 2017 Colin B. Macdonald
 %%
 %% This file is part of OctSymPy.
 %%
@@ -54,7 +55,10 @@ function y = ones(varargin)
     return
   end
 
-  y = python_cmd ('return ones(*_ins)', sym(varargin){:});
+  for i = 1:length(varargin)
+    varargin{i} = sym(varargin{i});
+  end
+  y = python_cmd ('return ones(*_ins)', varargin{:});
 
 end
 

--- a/inst/@sym/solve.m
+++ b/inst/@sym/solve.m
@@ -1,4 +1,4 @@
-%% Copyright (C) 2014-2016 Colin B. Macdonald
+%% Copyright (C) 2014-2017 Colin B. Macdonald
 %% Copyright (C) 2014-2015 Andrés Prieto
 %% Copyright (C) 2016 Lagu
 %%
@@ -104,7 +104,9 @@
 
 function varargout = solve(varargin)
 
-  varargin = sym(varargin);
+  for i = 1:nargin
+    varargin{i} = sym(varargin{i});
+  end
 
   if (nargout == 0 || nargout == 1)
     cmd = { 'eqs = list(); symbols = list()'

--- a/inst/@sym/subs.m
+++ b/inst/@sym/subs.m
@@ -1,4 +1,4 @@
-%% Copyright (C) 2014-2016 Colin B. Macdonald
+%% Copyright (C) 2014-2017 Colin B. Macdonald
 %%
 %% This file is part of OctSymPy.
 %%
@@ -123,8 +123,21 @@ function g = subs(f, in, out)
   %% In general
   % We build a list of of pairs of substitutions.
 
-  in = sym(in);
-  out = sym(out);
+  % ensure everything is sym
+  if (iscell (in))
+    for i = 1:length(in)
+      in{i} = sym(in{i});
+    end
+  else
+    in = sym(in);
+  end
+  if (iscell (out))
+    for i = 1:length(out)
+      out{i} = sym(out{i});
+    end
+  else
+    out = sym(out);
+  end
 
 
 

--- a/inst/@sym/subs.m
+++ b/inst/@sym/subs.m
@@ -125,14 +125,14 @@ function g = subs(f, in, out)
 
   % ensure everything is sym
   if (iscell (in))
-    for i = 1:length(in)
+    for i = 1:numel(in)
       in{i} = sym(in{i});
     end
   else
     in = sym(in);
   end
   if (iscell (out))
-    for i = 1:length(out)
+    for i = 1:numel(out)
       out{i} = sym(out{i});
     end
   else

--- a/inst/@sym/sym.m
+++ b/inst/@sym/sym.m
@@ -1,4 +1,4 @@
-%% Copyright (C) 2014-2016 Colin B. Macdonald
+%% Copyright (C) 2014-2017 Colin B. Macdonald
 %% Copyright (C) 2016 Lagu
 %%
 %% This file is part of OctSymPy.
@@ -198,6 +198,9 @@ function s = sym(x, varargin)
   end
 
   if (iscell (x))  % Handle Cells
+    warning ('OctSymPy:deprecated', ...
+            ['creating a cell array of sym using "sym(cell)" is deprecated;\n' ...
+             '         future versions will instead create a sym array.']);
     s = cell_array_to_sym (x, varargin{:});
     return
   end
@@ -488,42 +491,6 @@ end
 %! assert (isequal (sym (A), A))
 
 %!test
-%! % Cell array lists to syms
-%! % (these tests are pretty weak, doens't recursively compare two
-%! % cells, but just running this is a good test.
-%! x = sym ('x');
-%!
-%! a = {1 2};
-%! s = sym (a);
-%! assert (isequal (size (a), size (s)))
-%!
-%! a = {1 2 {3 4}};
-%! s = sym (a);
-%! assert (isequal (size (a), size (s)))
-%!
-%! a = {1 2; 3 4};
-%! s = sym (a);
-%! assert (isequal (size (a), size (s)))
-%!
-%! a = {1 2; 3 {4}};
-%! s = sym (a);
-%! assert (isequal (size (a), size (s)))
-%!
-%! a = {1 [1 2] x [sym(pi) x]};
-%! s = sym (a);
-%! assert (isequal (size (a), size (s)))
-%! assert (isequal (size (a{2}), size (s{2})))
-%! assert (isequal (size (a{4}), size (s{4})))
-%!
-%! a = {{{[1 2; 3 4]}}};
-%! s = sym (a);
-%! assert (isequal (size (a), size (s)))
-%! assert (isequal (size (a{1}), size (s{1})))
-%! assert (isequal (size (a{1}{1}), size (s{1}{1})))
-%! assert (isequal (size (a{1}{1}{1}), size (s{1}{1}{1})))
-
-
-%!test
 %! %% assumptions and clearing them
 %! clear  % for matlab test script
 %! x = sym('x', 'real');
@@ -773,8 +740,14 @@ end
 
 %!error <use another variable name> sym ('FF(w)');
 
+%!warning <deprecated> sym({1 2});
+
 %!test
+%! % multiple syms with assumptions
+%! % TODO: update this with #603
+%! s = warning ('off', 'OctSymPy:deprecated', 'local');
 %! q = sym ({'a', 'b', 'c'}, 'positive');
+%! warning (s)
 %! t = {};
 %! t{1, 1} = 'a: positive';
 %! t{1, 2} = 'b: positive';

--- a/inst/@sym/vertcat.m
+++ b/inst/@sym/vertcat.m
@@ -1,4 +1,4 @@
-%% Copyright (C) 2014-2016 Colin B. Macdonald
+%% Copyright (C) 2014-2017 Colin B. Macdonald
 %%
 %% This file is part of OctSymPy.
 %%
@@ -57,7 +57,9 @@ function h = vertcat(varargin)
           'return sp.MatrixBase.vstack(*_proc),'
           };
 
-  varargin = sym(varargin);
+  for i = 1:nargin
+    varargin{i} = sym(varargin{i});
+  end
   h = python_cmd (cmd, varargin{:});
 
 end

--- a/inst/@sym/zeros.m
+++ b/inst/@sym/zeros.m
@@ -1,5 +1,5 @@
 %% Copyright (C) 2016 Lagu
-%% Copyright (C) 2016 Colin B. Macdonald
+%% Copyright (C) 2017 Colin B. Macdonald
 %%
 %% This file is part of OctSymPy.
 %%
@@ -55,7 +55,10 @@ function y = zeros(varargin)
     return
   end
 
-  y = python_cmd ('return zeros(*_ins)', sym(varargin){:});
+  for i = 1:length(varargin)
+    varargin{i} = sym(varargin{i});
+  end
+  y = python_cmd ('return zeros(*_ins)', varargin{:});
 
 end
 

--- a/inst/cell2sym.m
+++ b/inst/cell2sym.m
@@ -1,4 +1,5 @@
 %% Copyright (C) 2016 Lagu
+%% Copyright (C) 2017 Colin B. Macdonald
 %%
 %% This program is free software; you can redistribute it and/or
 %% modify it under the terms of the GNU General Public
@@ -17,29 +18,28 @@
 
 %% -*- texinfo -*-
 %% @documentencoding UTF-8
-%% @defmethod @@sym cell2sym (@var{x})
+%% @defun @@sym cell2sym (@var{x})
 %% Convert cell array to symbolic array.
 %%
 %% Examples:
 %% @example
 %% @group
-%% syms x y
-%% cell2sym(@{x, y@})
+%% cell2sym(@{'x', 'y'@})
 %%   @result{} ans = (sym) [x  y]  (1×2 matrix)
 %% @end group
 %% @end example
 %%
 %% @example
 %% @group
-%% syms x y
 %% cell2sym(@{'x', 2; pi 'y'@})
 %%   @result{} ans = (sym 2×2 matrix)
-%%  ⎡x  2⎤
-%%  ⎢    ⎥
-%%  ⎣π  y⎦
+%%       ⎡x  2⎤
+%%       ⎢    ⎥
+%%       ⎣π  y⎦
 %% @end group
 %% @end example
-%% @end defmethod
+%% @seealso{sym, syms}
+%% @end defun
 
 function c = cell2sym(p)
 
@@ -65,6 +65,11 @@ end
 
 
 %!test
-%! A = {1, 2, 3; 4, 5, 6; 7, 8, 9};
-%! B = [1, 2, 3; 4, 5, 6; 7, 8, 9];
-%! assert( isequal( cell2sym(A), sym(B)))
+%! A = {1 2 3; 4 5 6};
+%! B = [1 2 3; 4 5 6];
+%! assert (isequal (cell2sym(A), sym(B)))
+
+%!test
+%! A = {'a' 'b'; 'c' 10};
+%! B = [sym('a') sym('b'); sym('c') sym(10)];
+%! assert (isequal (cell2sym(A), B))

--- a/inst/finiteset.m
+++ b/inst/finiteset.m
@@ -1,4 +1,4 @@
-%% Copyright (C) 2016 Colin B. Macdonald
+%% Copyright (C) 2016-2017 Colin B. Macdonald
 %%
 %% This file is part of OctSymPy.
 %%
@@ -59,7 +59,7 @@
 %% @end group
 %% @end example
 %%
-%% Careful, passing a matrix created a set of matrices (rather than a
+%% Careful, passing a matrix creates a set of matrices (rather than a
 %% set from the elements of the matrix):
 %% @example
 %% @group
@@ -115,9 +115,12 @@
 function S = finiteset(varargin)
 
   if (nargin == 1 && iscell(varargin{1}))
-    varargin = sym(varargin{1});
-  else
-    varargin = sym(varargin);
+    varargin = varargin{1};
+    nargin == length(varargin);
+  end
+
+  for i = 1:length(varargin)
+    varargin{i} = sym(varargin{i});
   end
 
   S = python_cmd ('return FiniteSet(*_ins),', varargin{:});

--- a/inst/finiteset.m
+++ b/inst/finiteset.m
@@ -114,12 +114,13 @@
 
 function S = finiteset(varargin)
 
+  % special case
   if (nargin == 1 && iscell(varargin{1}))
     varargin = varargin{1};
-    nargin == length(varargin);
+    nargin == numel (varargin);
   end
 
-  for i = 1:length(varargin)
+  for i = 1:numel(varargin)
     varargin{i} = sym(varargin{i});
   end
 


### PR DESCRIPTION
Basically this PR is to top using `varargin = sym(varargin)` and make calls to `sym(cell)` give a warning.