### PR TITLE
sympref: removed references to whichpython (fixes #723)

### DIFF
--- a/inst/sympref.m
+++ b/inst/sympref.m
@@ -186,11 +186,10 @@ function varargout = sympref(cmd, arg)
 
   if (isstruct (cmd))
     assert (isequal (sort (fieldnames (cmd)), ...
-      sort ({'ipc'; 'whichpython'; 'display'; 'digits'; 'quiet'})), ...
+      sort ({'ipc'; 'display'; 'digits'; 'quiet'})), ...
       'sympref: structure has incorrect field names')
     settings = [];
     sympref ('quiet', cmd.quiet)
-    settings.whichpython = cmd.whichpython;
     sympref ('display', cmd.display)
     sympref ('digits', cmd.digits)
     sympref ('ipc', cmd.ipc)
@@ -201,7 +200,6 @@ function varargout = sympref(cmd, arg)
     case 'defaults'
       settings = [];
       settings.ipc = 'default';
-      settings.whichpython = '';
       sympref ('display', 'default')
       sympref ('digits', 'default')
       sympref ('quiet', 'default')


### PR DESCRIPTION
I just removed the references in inst/sympref.m Is there some more stuff to remove or this is it for #723  ?