### PR TITLE
subsref: make output dims agree if input is vector

### DIFF
--- a/inst/@sym/private/mat_access.m
+++ b/inst/@sym/private/mat_access.m
@@ -38,8 +38,17 @@ function z = mat_access(A, subs)
                'A and I in A(I) not same shape: no problem, but did you intend this?')
     end
     subs{1} = find (subs{1});
-    if (isempty (subs{1}))
-      z = sym (zeros (size (subs{1})));
+    idx = subs{1};
+    if (isempty (idx))
+      % fix the dimensions when both A and idx are vectors
+      if (max (size (idx)) > 0)
+        if (iscolumn (A))
+          idx = idx(:);
+        elseif (isrow (A))
+          idx = idx(:)';
+        end
+      end
+      z = sym (zeros (size (idx)));
       return;
     end
 

--- a/inst/@sym/subsref.m
+++ b/inst/@sym/subsref.m
@@ -336,3 +336,18 @@ end
 %! test_bool (a, b, c)
 %! test_bool (a, b, c | true)
 %! test_bool (a, b, c & false)
+
+%!test
+%! % Orientation of empty results of logical indexing on row or column vectors
+%! r = [1:6];
+%! c = r';
+%! ar = sym(r);
+%! ac = sym(c);
+%! s = warning ('off', 'OctSymPy:subsref:index_matrix_not_same_shape');
+%! assert (isequal (ar(false), r(false)))
+%! assert (isequal (ac(false), c(false)))
+%! assert (isequal (ar(false (1, 6)), r(false (1, 6))))
+%! assert (isequal (ac(false (1, 6)), c(false (1, 6))))
+%! assert (isequal (ar(false (6, 1)), r(false (6, 1))))
+%! assert (isequal (ac(false (6, 1)), c(false (6, 1))))
+%! warning (s)


### PR DESCRIPTION
Something like this should fix #735.

Needs some tests added in subsref.m for the degenerate cases that are actually causing the random failures. Any improvements or suggestions to what I have so far?