### PR TITLE
added isequal for @symfun class (fixes #740)

### DIFF
--- a/inst/@symfun/int.m
+++ b/inst/@symfun/int.m
@@ -127,4 +127,4 @@ end
 %! g = int(f, y);
 %! assert (isa (g, 'symfun'))
 %! assert (isequal (argnames (g), x))
-%! assert (isequal (g, x^2*y))
+%! assert (isequal (formula(g), x^2*y))

--- a/inst/@symfun/isequal.m
+++ b/inst/@symfun/isequal.m
@@ -50,16 +50,11 @@
 
 function t = isequal(x, y, varargin)
 
-  t = logical(1);
-  if isa (x, 'symfun') && isa (y, 'symfun')
-    t = isequal (argnames(x), argnames(y));
+  t = isequal(formula(x), formula(y)) && isequal(argnames(x), argnames(y));
 
-    if nargin >= 3 && t == 1
-      t = t & isequal(x, varargin{:});
-    end
+  if nargin >= 3 && t
+    t = t & isequal(x, varargin{:});
   end
-
-  t = t & isequal(formula(x), formula(y));
 end
 
 

--- a/inst/@symfun/isequal.m
+++ b/inst/@symfun/isequal.m
@@ -1,0 +1,96 @@
+%% Copyright (C) 2017 NVS Abhilash
+%%
+%% This file is part of OctSymPy.
+%%
+%% OctSymPy is free software; you can redistribute it and/or modify
+%% it under the terms of the GNU General Public License as published
+%% by the Free Software Foundation; either version 3 of the License,
+%% or (at your option) any later version.
+%%
+%% This software is distributed in the hope that it will be useful,
+%% but WITHOUT ANY WARRANTY; without even the implied warranty
+%% of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See
+%% the GNU General Public License for more details.
+%%
+%% You should have received a copy of the GNU General Public
+%% License along with this software; see the file COPYING.
+%% If not, see <http://www.gnu.org/licenses/>.
+
+%% -*- texinfo -*-
+%% @documentencoding UTF-8
+%% @defmethod  @@symfun isequal (@var{f}, @var{g})
+%% @defmethodx @@symfun isequal (@var{f}, @var{g}, @dots{})
+%% Test if contents of two or more arrays are equal.
+%%
+%% Example:
+%% @example
+%% @group
+%% syms x
+%% f(x) = x + 1;
+%% g(x) = x + 1;
+%% isequal(f, g)
+%%   @result{} 1
+%% @end group
+%% @end example
+%%
+%% Note: two symfuns are equal if they have the same formula @emph{and}
+%% same arguments:
+%% @example
+%% @group
+%% syms x y
+%% f(x) = x + 1;
+%% g(x, y) = x + 1;
+%% isequal(f, g)
+%%   @result{} 0
+%% @end group
+%% @end example
+%%
+%% @seealso{@@sym/isequal, @@symfun/formula, @@symfun/argnames}
+%% @end defmethod
+
+function t = isequal(x, y, varargin)
+
+  t = logical(1);
+  if isa (x, 'symfun') && isa (y, 'symfun')
+    t = isequal (argnames(x), argnames(y));
+
+    if nargin >= 3 && t == 1
+      t = t & isequal(x, varargin{:});
+    end
+  end
+
+  t = t & isequal(formula(x), formula(y));
+end
+
+
+%!test
+%! syms x y
+%! f(x) = 2*x;
+%! g(x) = 2*x;
+%! assert (isequal (f, g))
+
+%!test
+%! syms x
+%! f(x) = 2*x + 1;
+%! g(x) = 2*x + 1;
+%! h(x) = 2*x + 1;
+%! assert (isequal (f, g, h))
+
+%!test
+%! syms x
+%! f(x) = 2*x + 1;
+%! g(x) = 2*x + 1;
+%! h(x) = 2*x;
+%! assert (~ isequal (f, g, h))
+
+%!test
+%! syms x y
+%! f(x) = 2*x;
+%! g(x, y) = 2*x;
+%! assert (~ isequal (f, g))
+
+%!test
+%! syms x y
+%! f(x) = symfun(nan, x);
+%! g(x) = symfun(nan, x);
+%! assert (~ isequal (f, g))

--- a/inst/@symfun/isequal.m
+++ b/inst/@symfun/isequal.m
@@ -50,13 +50,19 @@
 
 function t = isequal(x, y, varargin)
 
+  if (nargin <= 1)
+    print_usage ();
+  end
+
   t = isequal(formula(x), formula(y)) && isequal(argnames(x), argnames(y));
 
   if nargin >= 3 && t
     t = t && isequal(x, varargin{:});
   end
+
 end
 
+%!error isequal (symfun('x + 1', x))
 
 %!test
 %! syms x y

--- a/inst/@symfun/isequal.m
+++ b/inst/@symfun/isequal.m
@@ -53,7 +53,7 @@ function t = isequal(x, y, varargin)
   t = isequal(formula(x), formula(y)) && isequal(argnames(x), argnames(y));
 
   if nargin >= 3 && t
-    t = t & isequal(x, varargin{:});
+    t = t && isequal(x, varargin{:});
   end
 end
 

--- a/inst/@symfun/isequaln.m
+++ b/inst/@symfun/isequaln.m
@@ -1,0 +1,114 @@
+%% Copyright (C) 2017 NVS Abhilash
+%%
+%% This file is part of OctSymPy.
+%%
+%% OctSymPy is free software; you can redistribute it and/or modify
+%% it under the terms of the GNU General Public License as published
+%% by the Free Software Foundation; either version 3 of the License,
+%% or (at your option) any later version.
+%%
+%% This software is distributed in the hope that it will be useful,
+%% but WITHOUT ANY WARRANTY; without even the implied warranty
+%% of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See
+%% the GNU General Public License for more details.
+%%
+%% You should have received a copy of the GNU General Public
+%% License along with this software; see the file COPYING.
+%% If not, see <http://www.gnu.org/licenses/>.
+
+%% -*- texinfo -*-
+%% @documentencoding UTF-8
+%% @defmethod  @@symfun isequaln (@var{f}, @var{g})
+%% @defmethodx @@symfun isequaln (@var{f}, @var{g}, @dots{})
+%% Test if contents of two or more arrays are equal, even with nan.
+%%
+%% Example:
+%% @example
+%% @group
+%% syms x
+%% f(x) = x + 1;
+%% g(x) = x + 1;
+%% isequaln(f, g)
+%%   @result{} 1
+%% @end group
+%% @end example
+%%
+%% Note: two symfuns are equal if they have the same formula @emph{and}
+%% same arguments:
+%% @example
+%% @group
+%% syms x y
+%% f(x) = x + 1;
+%% g(x, y) = x + 1;
+%% isequaln(f, g)
+%%   @result{} 0
+%% @end group
+%% @end example
+%%
+%% Note: isequaln considers NaN's to be equal:
+%% @example
+%% @group
+%% syms x y
+%% f(x) = nan;
+%% g(x) = nan;
+%% isequaln(f, g)
+%%   @result{} 1
+%% @end group
+%% @end example
+%%
+%% @seealso{@@symfun/isequal, @@sym/isequal, @@symfun/formula, @@symfun/argnames}
+%% @end defmethod
+
+function t = isequaln(x, y, varargin)
+
+  if (nargin <= 1)
+    print_usage ();
+  end
+
+  t = isequaln(formula(x), formula(y)) && isequal(argnames(x), argnames(y));
+
+  if nargin >= 3 && t
+    t = t && isequaln(x, varargin{:});
+  end
+
+end
+
+%!error isequaln (symfun('x + 1', x))
+
+%!test
+%! syms x y
+%! f(x) = 2*x;
+%! g(x) = 2*x;
+%! assert (isequaln (f, g))
+
+%!test
+%! syms x
+%! f(x) = 2*x + 1;
+%! g(x) = 2*x + 1;
+%! h(x) = 2*x + 1;
+%! assert (isequaln (f, g, h))
+
+%!test
+%! syms x
+%! f(x) = 2*x + 1;
+%! g(x) = 2*x + 1;
+%! h(x) = 2*x;
+%! assert (~ isequaln (f, g, h))
+
+%!test
+%! syms x y
+%! f(x) = 2*x;
+%! g(x, y) = 2*x;
+%! assert (~ isequaln (f, g))
+
+%!test
+%! syms x y
+%! f(x) = symfun(nan, x);
+%! g(x) = symfun(nan, x);
+%! assert (isequaln (f, g))
+
+%!test
+%! syms x y
+%! f(x) = symfun(nan, x);
+%! g(x, y) = symfun(nan, x);
+%! assert (~ isequaln (f, g))

--- a/inst/@symfun/symfun.m
+++ b/inst/@symfun/symfun.m
@@ -263,7 +263,7 @@ end
 %! f(5);
 %! assert (length (argnames (f)) == 1)
 %! assert (isequal (argnames (f), t))
-%! assert (isequal( diff(f,x), sym(0)))
+%! assert (isequal( formula(diff(f,x)), sym(0)))
 
 %!test
 %! % replace g with shorter and specific fcn


### PR DESCRIPTION
Added isequal to @symfun to compare the `vars` of two `symfun` if they are not equal will return false otherwise will delegate the task of further checking to `isequaln`