### PR TITLE
tests: don't use plain "clear", for __run_test_suite__

### DIFF
--- a/inst/@sym/sym.m
+++ b/inst/@sym/sym.m
@@ -494,7 +494,7 @@ end
 
 %!test
 %! %% assumptions and clearing them
-%! clear  % for matlab test script
+%! clear variables  % for matlab test script
 %! x = sym('x', 'real');
 %! f = {x {2*x}};
 %! asm = assumptions();

--- a/inst/@symfun/symfun.m
+++ b/inst/@symfun/symfun.m
@@ -293,7 +293,7 @@ end
 
 %!test
 %! % syms f(x) without defining x
-%! clear
+%! clear x
 %! syms f(x)
 %! assert(isa(f, 'symfun'))
 %! assert(isa(x, 'sym'))

--- a/inst/assumptions.m
+++ b/inst/assumptions.m
@@ -169,10 +169,10 @@ end
 %! assert(isempty(assumptions(x)))
 
 %!test
-%! clear  % for matlab test script
+%! clear variables  % for matlab test script
 %! syms x positive
 %! assert(~isempty(assumptions()))
-%! clear
+%! clear x
 %! assert(isempty(assumptions()))
 
 %!test
@@ -220,7 +220,7 @@ end
 
 %!test
 %! %% assumptions on just the vars in an expression
-%! clear  % for matlab test script
+%! clear variables  % for matlab test script
 %! syms x y positive
 %! f = 2*x;
 %! assert(length(assumptions(f))==1)
@@ -228,7 +228,7 @@ end
 
 %!test
 %! %% assumptions in cell/struct
-%! clear  % for matlab test script
+%! clear variables  % for matlab test script
 %! syms x y z w positive
 %! f = {2*x [1 2 y] {1, {z}}};
 %! assert(length(assumptions())==4)


### PR DESCRIPTION
Octave has a __run_test_suite__ command which doesn't like "clear"
being done during tests (because it relies on some global variables
I think).  Usually we can just clear the specific variable we need
cleared.  In other cases "clear variables" should do and seems
portable between Octave and Matlab.