### PR TITLE
add elliptic integrals

### DIFF
--- a/inst/@sym/ellipke.m
+++ b/inst/@sym/ellipke.m
@@ -1,0 +1,97 @@
+%% Copyright (C) 2016 Lagu
+%%
+%% This file is part of OctSymPy.
+%%
+%% OctSymPy is free software; you can redistribute it and/or modify
+%% it under the terms of the GNU General Public License as published
+%% by the Free Software Foundation; either version 3 of the License,
+%% or (at your option) any later version.
+%%
+%% This software is distributed in the hope that it will be useful,
+%% but WITHOUT ANY WARRANTY; without even the implied warranty
+%% of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See
+%% the GNU General Public License for more details.
+%%
+%% You should have received a copy of the GNU General Public
+%% License along with this software; see the file COPYING.
+%% If not, see <http://www.gnu.org/licenses/>.
+
+%% -*- texinfo -*-
+%% @documentencoding UTF-8
+%% @defmethod @@sym [K E] = ellipke (@var{m})
+%% Complete elliptic integrals of the first and second kinds.
+%%
+%% Example:
+%% @example
+%% @group
+%% syms m
+%% [K E] = ellipke (m)
+%%   @result{}
+%%     K = (sym) K(m)
+%%     E = (sym) E(m)
+%% @end group
+%%
+%% @group
+%% rewrite (K, 'Integral')         % doctest: +SKIP
+%%   @result{}
+%%     K = (sym)
+%%       π
+%%       ─
+%%       2
+%%       ⌠
+%%       ⎮          1
+%%       ⎮ ──────────────────── dα
+%%       ⎮    _________________
+%%       ⎮   ╱        2
+%%       ⎮ ╲╱  - m⋅sin (α) + 1
+%%       ⌡
+%%       0
+%% @end group
+%%
+%% @group
+%% rewrite (E, 'Integral')         % doctest: +SKIP
+%%     E = (sym)
+%%
+%%       π
+%%       ─
+%%       2
+%%       ⌠
+%%       ⎮
+%%       ⎮   ╱        2
+%%       ⎮ ╲╱  - m⋅sin (α) + 1  dα
+%%       ⌡
+%%       0
+%% @end group
+%% @group
+%% [K E] = ellipke (sym (1)/10);
+%% double ([K E])
+%%   @result{} ans =
+%%        1.6124   1.5308
+%% @end group
+%% @end example
+%%
+%% @seealso{@@sym/ellipticF, @@sym/ellipticE, @@sym/ellipticPi}
+%% @end defmethod
+
+
+function varargout = ellipke(m)
+
+  if (nargin ~= 1 || nargout > 2)
+    print_usage ();
+  end
+
+  if (nargout == 0 || nargout == 1)
+    varargout = {ellipticF(sym (pi)/2, m)};
+  else
+    varargout = {ellipticF(sym (pi)/2, m) ellipticE(sym (pi)/2, m)};
+  end
+
+end
+
+
+%!test
+%! for i = 2:10
+%!   [K E] = ellipke (sym (1)/i);
+%!   [k e] = ellipke (1/i);
+%!   assert (double ([K E]), [k e], 2*eps)
+%! end

--- a/inst/@sym/ellipke.m
+++ b/inst/@sym/ellipke.m
@@ -1,4 +1,5 @@
 %% Copyright (C) 2016-2017 Lagu
+%% Copyright (C) 2017 Colin B. Macdonald
 %%
 %% This file is part of OctSymPy.
 %%
@@ -26,47 +27,8 @@
 %% @group
 %% syms m
 %% [K, E] = ellipke (m)
-%%   @result{}
-%%     K = (sym) K(m)
-%%     E = (sym) E(m)
-%% @end group
-%%
-%% @group
-%% rewrite (K, 'Integral')         % doctest: +SKIP
-%%   @result{}
-%%     K = (sym)
-%%       π
-%%       ─
-%%       2
-%%       ⌠
-%%       ⎮          1
-%%       ⎮ ──────────────────── dα
-%%       ⎮    _________________
-%%       ⎮   ╱        2
-%%       ⎮ ╲╱  - m⋅sin (α) + 1
-%%       ⌡
-%%       0
-%% @end group
-%%
-%% @group
-%% rewrite (E, 'Integral')         % doctest: +SKIP
-%%     E = (sym)
-%%
-%%       π
-%%       ─
-%%       2
-%%       ⌠
-%%       ⎮    _________________
-%%       ⎮   ╱        2
-%%       ⎮ ╲╱  - m⋅sin (α) + 1  dα
-%%       ⌡
-%%       0
-%% @end group
-%% @group
-%% [K, E] = ellipke (sym (1)/10);
-%% double ([K E])
-%%   @result{} ans =
-%%        1.6124   1.5308
+%%   @result{} K = (sym) K(m)
+%%   @result{} E = (sym) E(m)
 %% @end group
 %% @end example
 %%

--- a/inst/@sym/ellipke.m
+++ b/inst/@sym/ellipke.m
@@ -18,14 +18,14 @@
 
 %% -*- texinfo -*-
 %% @documentencoding UTF-8
-%% @defmethod @@sym [K E] = ellipke (@var{m})
+%% @defmethod @@sym [@var{K}, @var{E}] = ellipke (@var{m})
 %% Complete elliptic integrals of the first and second kinds.
 %%
 %% Example:
 %% @example
 %% @group
 %% syms m
-%% [K E] = ellipke (m)
+%% [K, E] = ellipke (m)
 %%   @result{}
 %%     K = (sym) K(m)
 %%     E = (sym) E(m)
@@ -56,21 +56,21 @@
 %%       ─
 %%       2
 %%       ⌠
-%%       ⎮
+%%       ⎮    _________________
 %%       ⎮   ╱        2
 %%       ⎮ ╲╱  - m⋅sin (α) + 1  dα
 %%       ⌡
 %%       0
 %% @end group
 %% @group
-%% [K E] = ellipke (sym (1)/10);
+%% [K, E] = ellipke (sym (1)/10);
 %% double ([K E])
 %%   @result{} ans =
 %%        1.6124   1.5308
 %% @end group
 %% @end example
 %%
-%% @seealso{@@sym/ellipticF, @@sym/ellipticE, @@sym/ellipticPi}
+%% @seealso{ellipke, @@sym/ellipticK, @@sym/ellipticE}
 %% @end defmethod
 
 
@@ -88,6 +88,8 @@ function varargout = ellipke(m)
 
 end
 
+
+%!error <Invalid> ellipke (sym(1), 2)
 
 %!test
 %! for i = 2:10

--- a/inst/@sym/ellipke.m
+++ b/inst/@sym/ellipke.m
@@ -1,4 +1,4 @@
-%% Copyright (C) 2016 Lagu
+%% Copyright (C) 2016-2017 Lagu
 %%
 %% This file is part of OctSymPy.
 %%

--- a/inst/@sym/ellipke.m
+++ b/inst/@sym/ellipke.m
@@ -81,9 +81,9 @@ function varargout = ellipke(m)
   end
 
   if (nargout == 0 || nargout == 1)
-    varargout = {ellipticF(sym (pi)/2, m)};
+    varargout = {ellipticK(m)};
   else
-    varargout = {ellipticF(sym (pi)/2, m) ellipticE(sym (pi)/2, m)};
+    varargout = {ellipticK(m) ellipticE(m)};
   end
 
 end

--- a/inst/@sym/ellipticCE.m
+++ b/inst/@sym/ellipticCE.m
@@ -21,30 +21,23 @@
 %% @defmethod @@sym ellipticCE (@var{m})
 %% Complementary complete elliptic integral of the second kind.
 %%
-%% Example:
+%% This is the complete elliptic integral (of the second kind) with the
+%% complementary parameter @code{1 - @var{m}}:
 %% @example
 %% @group
 %% syms m
 %% ellipticCE (m)
 %%   @result{} ans = (sym) E(-m + 1)
 %% @end group
+%% @end example
 %%
+%% Example:
+%% @example
 %% @group
-%% rewrite (ans, 'Integral')         % doctest: +SKIP
-%%   @result{} ans = (sym)
-%%       π
-%%       ─
-%%       2
-%%       ⌠
-%%       ⎮    ________________________
-%%       ⎮   ╱               2
-%%       ⎮ ╲╱  - (-m + 1)⋅sin (α) + 1  dα
-%%       ⌡
-%%       0
-%% @end group
-%% @group
-%% double (ellipticCE (sym (pi)/4))
-%%   @result{} ans =  1.4828
+%% ellipticCE (sym(1)/3)
+%%   @result{} ans = (sym) E(2/3)
+%% double (ans)
+%%   @result{} ans = 1.2612
 %% @end group
 %% @end example
 %%
@@ -53,8 +46,8 @@
 
 
 function y = ellipticCE(m)
-  if nargin > 1
-    print_usage();
+  if (nargin > 1)
+    print_usage ();
   end
 
   y = ellipticE (sym (pi)/2, 1 - m);
@@ -62,7 +55,9 @@ function y = ellipticCE(m)
 end
 
 
-%!assert (double (ellipticCE (sym (0))), 1)
+%!error <Invalid> ellipticCE (sym (1), 2)
+
+%!assert (isequal (ellipticCE (sym (0)), sym (1)))
+%!assert (isequal (ellipticCE (sym (1)), sym (pi)/2))
 %!assert (double (ellipticCE (sym (pi)/4)), 1.482786927, 10e-10)
-%!assert (double (ellipticCE (sym (1))), 1.570796327, 10e-10)
-%!assert (double (ellipticCE (sym (pi)/2)), 1.775344699, 10e-1)
+%!assert (double (ellipticCE (sym (pi)/2)), 1.775344699, 10e-10)

--- a/inst/@sym/ellipticCE.m
+++ b/inst/@sym/ellipticCE.m
@@ -1,4 +1,5 @@
 %% Copyright (C) 2016-2017 Lagu
+%% Copyright (C) 2017 Colin B. Macdonald
 %%
 %% This file is part of OctSymPy.
 %%
@@ -21,8 +22,8 @@
 %% @defmethod @@sym ellipticCE (@var{m})
 %% Complementary complete elliptic integral of the second kind.
 %%
-%% This is the complete elliptic integral (of the second kind) with the
-%% complementary parameter @code{1 - @var{m}}:
+%% The complete elliptic integral (of the second kind) with the
+%% complementary parameter @code{1 - @var{m}} is given by:
 %% @example
 %% @group
 %% syms m
@@ -31,7 +32,7 @@
 %% @end group
 %% @end example
 %%
-%% Example:
+%% Examples:
 %% @example
 %% @group
 %% ellipticCE (sym(1)/3)

--- a/inst/@sym/ellipticCE.m
+++ b/inst/@sym/ellipticCE.m
@@ -37,8 +37,8 @@
 %% @group
 %% ellipticCE (sym(1)/3)
 %%   @result{} ans = (sym) E(2/3)
-%% double (ans)
-%%   @result{} ans = 1.2612
+%% vpa (ans)
+%%   @result{} (sym) 1.2611859497426054059627955614384
 %% @end group
 %% @end example
 %%

--- a/inst/@sym/ellipticCE.m
+++ b/inst/@sym/ellipticCE.m
@@ -1,4 +1,4 @@
-%% Copyright (C) 2016 Lagu
+%% Copyright (C) 2016-2017 Lagu
 %%
 %% This file is part of OctSymPy.
 %%

--- a/inst/@sym/ellipticCE.m
+++ b/inst/@sym/ellipticCE.m
@@ -41,6 +41,9 @@
 %% @end group
 %% @end example
 %%
+%% There are other conventions for the inputs of elliptic integrals,
+%% @pxref{@@sym/ellipticF}.
+%%
 %% @seealso{@@sym/ellipticE}
 %% @end defmethod
 

--- a/inst/@sym/ellipticCE.m
+++ b/inst/@sym/ellipticCE.m
@@ -1,0 +1,68 @@
+%% Copyright (C) 2016 Lagu
+%%
+%% This file is part of OctSymPy.
+%%
+%% OctSymPy is free software; you can redistribute it and/or modify
+%% it under the terms of the GNU General Public License as published
+%% by the Free Software Foundation; either version 3 of the License,
+%% or (at your option) any later version.
+%%
+%% This software is distributed in the hope that it will be useful,
+%% but WITHOUT ANY WARRANTY; without even the implied warranty
+%% of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See
+%% the GNU General Public License for more details.
+%%
+%% You should have received a copy of the GNU General Public
+%% License along with this software; see the file COPYING.
+%% If not, see <http://www.gnu.org/licenses/>.
+
+%% -*- texinfo -*-
+%% @documentencoding UTF-8
+%% @defmethod @@sym ellipticCE (@var{m})
+%% Complementary complete elliptic integral of the second kind.
+%%
+%% Example:
+%% @example
+%% @group
+%% syms m
+%% ellipticCE (m)
+%%   @result{} ans = (sym) E(-m + 1)
+%% @end group
+%%
+%% @group
+%% rewrite (ans, 'Integral')         % doctest: +SKIP
+%%   @result{} ans = (sym)
+%%       π
+%%       ─
+%%       2
+%%       ⌠
+%%       ⎮    ________________________
+%%       ⎮   ╱               2
+%%       ⎮ ╲╱  - (-m + 1)⋅sin (α) + 1  dα
+%%       ⌡
+%%       0
+%% @end group
+%% @group
+%% double (ellipticCE (sym (pi)/4))
+%%   @result{} ans =  1.4828
+%% @end group
+%% @end example
+%%
+%% @seealso{@@sym/ellipticE}
+%% @end defmethod
+
+
+function y = ellipticCE(m)
+  if nargin > 1
+    print_usage();
+  end
+
+  y = ellipticE (sym (pi)/2, 1 - m);
+
+end
+
+
+%!assert (double (ellipticCE (sym (0))), 1)
+%!assert (double (ellipticCE (sym (pi)/4)), 1.482786927, 10e-10)
+%!assert (double (ellipticCE (sym (1))), 1.570796327, 10e-10)
+%!assert (double (ellipticCE (sym (pi)/2)), 1.775344699, 10e-1)

--- a/inst/@sym/ellipticCK.m
+++ b/inst/@sym/ellipticCK.m
@@ -22,8 +22,8 @@
 %% @defmethod @@sym ellipticCK (@var{m})
 %% Complementary complete elliptic integral of the first kind.
 %%
-%% This is the complete elliptic integral (of the first kind) with the
-%% complementary parameter @code{1 - @var{m}}:
+%% The complete elliptic integral (of the first kind) with the
+%% complementary parameter @code{1 - @var{m}} is given by:
 %% @example
 %% @group
 %% syms m

--- a/inst/@sym/ellipticCK.m
+++ b/inst/@sym/ellipticCK.m
@@ -1,0 +1,67 @@
+%% Copyright (C) 2016 Lagu
+%%
+%% This file is part of OctSymPy.
+%%
+%% OctSymPy is free software; you can redistribute it and/or modify
+%% it under the terms of the GNU General Public License as published
+%% by the Free Software Foundation; either version 3 of the License,
+%% or (at your option) any later version.
+%%
+%% This software is distributed in the hope that it will be useful,
+%% but WITHOUT ANY WARRANTY; without even the implied warranty
+%% of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See
+%% the GNU General Public License for more details.
+%%
+%% You should have received a copy of the GNU General Public
+%% License along with this software; see the file COPYING.
+%% If not, see <http://www.gnu.org/licenses/>.
+
+%% -*- texinfo -*-
+%% @documentencoding UTF-8
+%% @defmethod @@sym ellipticCK (@var{m})
+%% Complementary complete elliptic integral of the first kind.
+%%
+%% Example:
+%% @example
+%% @group
+%% syms m
+%% ellipticCK (m)
+%%   @result{} ans = (sym) K(m)
+%% @end group
+%%
+%% @group
+%% rewrite (ans, 'Integral')         % doctest: +SKIP
+%%   @result{} ans = (sym)
+%%       π
+%%       ─
+%%       2
+%%       ⌠
+%%       ⎮          1
+%%       ⎮ ──────────────────── dα
+%%       ⎮    _________________
+%%       ⎮   ╱        2
+%%       ⎮ ╲╱  - m⋅sin (α) + 1
+%%       ⌡
+%%       0
+%% @end group
+%% @group
+%% double (ellipticCK (sym (1)/2))
+%%   @result{} ans =  1.8541
+%% @end group
+%% @end example
+%%
+%% @seealso{@@sym/ellipticF, @@sym/ellipticPi}
+%% @end defmethod
+
+
+function y = ellipticCK(m)
+  if nargin > 1
+    print_usage();
+  end
+
+  y = ellipticF (sym (pi)/2, m);
+
+end
+
+
+%!assert (double (ellipticCK (sym (1)/2)), 1.8541, 10e-5)

--- a/inst/@sym/ellipticCK.m
+++ b/inst/@sym/ellipticCK.m
@@ -1,4 +1,5 @@
 %% Copyright (C) 2016-2017 Lagu
+%% Copyright (C) 2017 Colin B. Macdonald
 %%
 %% This file is part of OctSymPy.
 %%
@@ -21,47 +22,42 @@
 %% @defmethod @@sym ellipticCK (@var{m})
 %% Complementary complete elliptic integral of the first kind.
 %%
-%% Example:
+%% This is the complete elliptic integral (of the first kind) with the
+%% complementary parameter @code{1 - @var{m}}:
 %% @example
 %% @group
 %% syms m
 %% ellipticCK (m)
-%%   @result{} ans = (sym) K(m)
-%% @end group
-%%
-%% @group
-%% rewrite (ans, 'Integral')         % doctest: +SKIP
-%%   @result{} ans = (sym)
-%%       π
-%%       ─
-%%       2
-%%       ⌠
-%%       ⎮          1
-%%       ⎮ ──────────────────── dα
-%%       ⎮    _________________
-%%       ⎮   ╱        2
-%%       ⎮ ╲╱  - m⋅sin (α) + 1
-%%       ⌡
-%%       0
-%% @end group
-%% @group
-%% double (ellipticCK (sym (1)/2))
-%%   @result{} ans =  1.8541
+%%   @result{} ans = (sym) K(-m + 1)
 %% @end group
 %% @end example
 %%
-%% @seealso{@@sym/ellipticF, @@sym/ellipticPi}
+%% Example:
+%% @example
+%% @group
+%% ellipticCK (sym (1)/4)
+%%   @result{} ans = (sym) K(3/4)
+%% double (ans)
+%%   @result{} ans = 2.1565
+%% @end group
+%% @end example
+%%
+%% @seealso{@@sym/ellipticK}
 %% @end defmethod
 
 
-function y = ellipticCK(m)
-  if nargin > 1
-    print_usage();
+function y = ellipticCK (m)
+  if (nargin > 1)
+    print_usage ();
   end
 
-  y = ellipticF (sym (pi)/2, m);
+  y = ellipticK (1 - m);
 
 end
 
 
+%!error <Invalid> ellipticCK (sym (1), 2)
+
 %!assert (double (ellipticCK (sym (1)/2)), 1.8541, 10e-5)
+%!assert (double (ellipticCK (sym (101)/10)), 0.812691836806976, -3*eps)
+%!assert (isequal (ellipticCK (sym (1)), sym(pi)/2))

--- a/inst/@sym/ellipticCK.m
+++ b/inst/@sym/ellipticCK.m
@@ -37,8 +37,8 @@
 %% @group
 %% ellipticCK (sym (1)/4)
 %%   @result{} ans = (sym) K(3/4)
-%% double (ans)
-%%   @result{} ans = 2.1565
+%% vpa (ans)
+%%   @result{} (sym) 2.1565156474996432354386749988003
 %% @end group
 %% @end example
 %%

--- a/inst/@sym/ellipticCK.m
+++ b/inst/@sym/ellipticCK.m
@@ -42,6 +42,9 @@
 %% @end group
 %% @end example
 %%
+%% There are other conventions for the inputs of elliptic integrals,
+%% @pxref{@@sym/ellipticF}.
+%%
 %% @seealso{@@sym/ellipticK}
 %% @end defmethod
 

--- a/inst/@sym/ellipticCK.m
+++ b/inst/@sym/ellipticCK.m
@@ -1,4 +1,4 @@
-%% Copyright (C) 2016 Lagu
+%% Copyright (C) 2016-2017 Lagu
 %%
 %% This file is part of OctSymPy.
 %%

--- a/inst/@sym/ellipticCPi.m
+++ b/inst/@sym/ellipticCPi.m
@@ -1,0 +1,67 @@
+%% Copyright (C) 2016 Lagu
+%%
+%% This file is part of OctSymPy.
+%%
+%% OctSymPy is free software; you can redistribute it and/or modify
+%% it under the terms of the GNU General Public License as published
+%% by the Free Software Foundation; either version 3 of the License,
+%% or (at your option) any later version.
+%%
+%% This software is distributed in the hope that it will be useful,
+%% but WITHOUT ANY WARRANTY; without even the implied warranty
+%% of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See
+%% the GNU General Public License for more details.
+%%
+%% You should have received a copy of the GNU General Public
+%% License along with this software; see the file COPYING.
+%% If not, see <http://www.gnu.org/licenses/>.
+
+%% -*- texinfo -*-
+%% @documentencoding UTF-8
+%% @defmethod @@sym ellipticCPi (@var{n}, @var{m})
+%% Complementary complete elliptic integral of the third kind.
+%%
+%% Example:
+%% @example
+%% @group
+%% syms n m
+%% ellipticCPi (n, m)
+%%   @result{} ans = (sym) Π(n│m)
+%% @end group
+%%
+%% @group
+%% rewrite (ans, 'Integral')         % doctest: +SKIP
+%%   @result{} ans = (sym)
+%%       π
+%%       ─
+%%       2
+%%       ⌠
+%%       ⎮                   1
+%%       ⎮ ────────────────────────────────────── dα
+%%       ⎮    _________________
+%%       ⎮   ╱        2         ⎛       2       ⎞
+%%       ⎮ ╲╱  - m⋅sin (α) + 1 ⋅⎝- n⋅sin (α) + 1⎠
+%%       ⌡
+%%       0
+%% @end group
+%% @group
+%% double (ellipticCPi (sym (0), sym (1)/2))
+%%   @result{} ans =  1.8541
+%% @end group
+%% @end example
+%%
+%% @seealso{@@sym/ellipticPi}
+%% @end defmethod
+
+
+function y = ellipticCPi(n, m)
+  if nargin ~= 2
+    print_usage();
+  end
+
+  y = ellipticPi (n, sym (pi)/2, m);
+
+end
+
+
+%!assert (double (ellipticCPi (0, sym (1)/2)), 1.854074677, 10e-10)

--- a/inst/@sym/ellipticCPi.m
+++ b/inst/@sym/ellipticCPi.m
@@ -47,6 +47,9 @@
 %% @end group
 %% @end example
 %%
+%% There are other conventions for the inputs of elliptic integrals,
+%% @pxref{@@sym/ellipticF}.
+%%
 %% @seealso{@@sym/ellipticPi}
 %% @end defmethod
 

--- a/inst/@sym/ellipticCPi.m
+++ b/inst/@sym/ellipticCPi.m
@@ -1,4 +1,4 @@
-%% Copyright (C) 2016 Lagu
+%% Copyright (C) 2016-2017 Lagu
 %%
 %% This file is part of OctSymPy.
 %%

--- a/inst/@sym/ellipticCPi.m
+++ b/inst/@sym/ellipticCPi.m
@@ -1,4 +1,5 @@
 %% Copyright (C) 2016-2017 Lagu
+%% Copyright (C) 2017 Colin B. Macdonald
 %%
 %% This file is part of OctSymPy.
 %%
@@ -21,32 +22,28 @@
 %% @defmethod @@sym ellipticCPi (@var{n}, @var{m})
 %% Complementary complete elliptic integral of the third kind.
 %%
-%% Example:
+%% This is the complete elliptic integral (of the third kind) with the
+%% complementary parameter @code{1 - @var{m}}:
 %% @example
 %% @group
 %% syms n m
 %% ellipticCPi (n, m)
-%%   @result{} ans = (sym) Π(n│m)
+%%   @result{} ans = (sym) Π(n│-m + 1)
+%% @end group
+%% @end example
+%%
+%% Example:
+%% @example
+%% @group
+%% ellipticCPi (n, sym(1)/4)
+%%   @result{} ans = (sym) Π(n│3/4)
 %% @end group
 %%
 %% @group
-%% rewrite (ans, 'Integral')         % doctest: +SKIP
-%%   @result{} ans = (sym)
-%%       π
-%%       ─
-%%       2
-%%       ⌠
-%%       ⎮                   1
-%%       ⎮ ────────────────────────────────────── dα
-%%       ⎮    _________________
-%%       ⎮   ╱        2         ⎛       2       ⎞
-%%       ⎮ ╲╱  - m⋅sin (α) + 1 ⋅⎝- n⋅sin (α) + 1⎠
-%%       ⌡
-%%       0
-%% @end group
-%% @group
-%% double (ellipticCPi (sym (0), sym (1)/2))
-%%   @result{} ans =  1.8541
+%% ellipticCPi (sym(1)/2, sym(1)/4)
+%%   @result{} ans = (sym) Π(1/2│3/4)
+%% double (ans)
+%%   @result{} ans = 3.2348
 %% @end group
 %% @end example
 %%
@@ -55,13 +52,17 @@
 
 
 function y = ellipticCPi(n, m)
-  if nargin ~= 2
-    print_usage();
+  if (nargin ~= 2)
+    print_usage ();
   end
 
-  y = ellipticPi (n, sym (pi)/2, m);
+  y = ellipticPi (n, sym (pi)/2, 1 - m);
 
 end
 
+%!error <Invalid> ellipticCPi (sym (1))
+%!error <Invalid> ellipticCPi (sym (1), 2, 3)
 
 %!assert (double (ellipticCPi (0, sym (1)/2)), 1.854074677, 10e-10)
+
+%!assert (double (ellipticCPi (sym (6)/10, sym(71)/10)), 1.29469534336658, -20*eps)

--- a/inst/@sym/ellipticCPi.m
+++ b/inst/@sym/ellipticCPi.m
@@ -42,8 +42,8 @@
 %% @group
 %% ellipticCPi (sym(1)/2, sym(1)/4)
 %%   @result{} ans = (sym) Π(1/2│3/4)
-%% double (ans)
-%%   @result{} ans = 3.2348
+%% vpa (ans)
+%%   @result{} (sym) 3.2347734712494648531580124982005
 %% @end group
 %% @end example
 %%

--- a/inst/@sym/ellipticCPi.m
+++ b/inst/@sym/ellipticCPi.m
@@ -19,24 +19,24 @@
 
 %% -*- texinfo -*-
 %% @documentencoding UTF-8
-%% @defmethod @@sym ellipticCPi (@var{n}, @var{m})
+%% @defmethod @@sym ellipticCPi (@var{nu}, @var{m})
 %% Complementary complete elliptic integral of the third kind.
 %%
 %% This is the complete elliptic integral (of the third kind) with the
 %% complementary parameter @code{1 - @var{m}}:
 %% @example
 %% @group
-%% syms n m
-%% ellipticCPi (n, m)
-%%   @result{} ans = (sym) Π(n│-m + 1)
+%% syms nu m
+%% ellipticCPi (nu, m)
+%%   @result{} ans = (sym) Π(ν│-m + 1)
 %% @end group
 %% @end example
 %%
-%% Example:
+%% Examples:
 %% @example
 %% @group
-%% ellipticCPi (n, sym(1)/4)
-%%   @result{} ans = (sym) Π(n│3/4)
+%% ellipticCPi (nu, sym(1)/4)
+%%   @result{} ans = (sym) Π(ν│3/4)
 %% @end group
 %%
 %% @group

--- a/inst/@sym/ellipticE.m
+++ b/inst/@sym/ellipticE.m
@@ -23,8 +23,8 @@
 %% @defmethodx @@sym ellipticE (@var{phi}, @var{m})
 %% Complete and incomplete elliptic integrals of the second kind.
 %%
-%% Incomplete elliptic integral of the second kind with
-%% amplitude @var{phi} and parameter @var{m}:
+%% The incomplete elliptic integral of the second kind with
+%% amplitude @var{phi} and parameter @var{m} is given by:
 %% @example
 %% @group
 %% syms phi m
@@ -50,8 +50,8 @@
 %% @end group
 %% @end example
 %%
-%% Complete elliptic integral of the second kind with
-%% parameter @var{m}:
+%% The complete elliptic integral of the second kind with
+%% parameter @var{m} is given by:
 %% @example
 %% @group
 %% ellipticE (m)

--- a/inst/@sym/ellipticE.m
+++ b/inst/@sym/ellipticE.m
@@ -23,7 +23,8 @@
 %% @defmethodx @@sym ellipticE (@var{phi}, @var{m})
 %% Complete and incomplete elliptic integrals of the second kind.
 %%
-%% Incomplete elliptic integral of the second kind:
+%% Incomplete elliptic integral of the second kind with
+%% amplitude @var{phi} and parameter @var{m}:
 %% @example
 %% @group
 %% syms phi m
@@ -49,7 +50,8 @@
 %% @end group
 %% @end example
 %%
-%% Complete elliptic integral of the second kind:
+%% Complete elliptic integral of the second kind with
+%% parameter @var{m}:
 %% @example
 %% @group
 %% ellipticE (m)

--- a/inst/@sym/ellipticE.m
+++ b/inst/@sym/ellipticE.m
@@ -19,7 +19,7 @@
 
 %% -*- texinfo -*-
 %% @documentencoding UTF-8
-%% @defmethod @@sym ellipticE (@var{m})
+%% @defmethod  @@sym ellipticE (@var{m})
 %% @defmethodx @@sym ellipticE (@var{phi}, @var{m})
 %% Complete and incomplete elliptic integrals of the second kind.
 %%
@@ -75,7 +75,7 @@
 %%   @result{} ans =  1.8443
 %% @end group
 %% @end example
-%% @seealso{@@sym/ellipticK, ellipke}
+%% @seealso{@@sym/ellipke, @@sym/ellipticK, @@sym/ellipticPi}
 %% @end defmethod
 
 
@@ -94,6 +94,8 @@ function y = ellipticE(phi, m)
 
 end
 
+
+%!error <Invalid> ellipticE (sym(1), 2, 3)
 
 %!assert (double (ellipticE (sym (-105)/10)), 3.70961391, 10e-9)
 %!assert (double (ellipticE (sym (-pi)/4)), 1.844349247, 10e-10)

--- a/inst/@sym/ellipticE.m
+++ b/inst/@sym/ellipticE.m
@@ -79,7 +79,7 @@
 %% @end defmethod
 
 
-function y = ellipticE(phi, m)
+function y = ellipticE (phi, m)
 
   if (nargin == 1)
     m = phi;

--- a/inst/@sym/ellipticE.m
+++ b/inst/@sym/ellipticE.m
@@ -103,3 +103,19 @@ end
 %!assert (double (ellipticE (sym (-pi)/4)), 1.844349247, 10e-10)
 %!assert (double (ellipticE (sym (0))), 1.570796327, 10e-10)
 %!assert (double (ellipticE (sym (1))), 1, 10e-1)
+
+%!test
+%! % compare to Maple
+%! us = vpa (ellipticE (sym(7)/6, sym(13)/7), 40);
+%! % > evalf(EllipticE(sin(7/6), sqrt(13/7)), 40);
+%! maple = vpa ('0.6263078268598504591831743625971763209496', 40) + ...
+%!         vpa ('0.1775496232203171126975790989055865596501j', 40);
+%! assert (abs (double (maple - us)), 0, 2e-39)
+
+%!test
+%! % compare to Maple
+%! us = vpa (ellipticE (sym(8)/7), 40);
+%! % > evalf(EllipticE(sqrt(8/7)), 40);
+%! maple = vpa ('0.8717182992576322508542205614105802333270', 40) + ...
+%!         vpa ('0.1066754320328976949531350910798010526685j', 40);
+%! assert (abs (double (maple - us)), 0, 2e-39)

--- a/inst/@sym/ellipticE.m
+++ b/inst/@sym/ellipticE.m
@@ -43,11 +43,6 @@
 %%       ⌡
 %%       0
 %% @end group
-%%
-%% @group
-%% double (ellipticE (sym (1), sym (1)/10))
-%%   @result{} ans =  0.98621
-%% @end group
 %% @end example
 %%
 %% The complete elliptic integral of the second kind with
@@ -71,10 +66,18 @@
 %%       ⌡
 %%       0
 %% @end group
+%% @end example
+%%
+%% Examples:
+%% @example
+%% @group
+%% vpa (ellipticE (sym (1), sym (1)/10))
+%%   @result{} (sym) 0.98620694978157550636951680164874
+%% @end group
 %%
 %% @group
-%% double (ellipticE (sym (-pi)/4))
-%%   @result{} ans =  1.8443
+%% vpa (ellipticE (sym (-pi)/4))
+%%   @result{} (sym) 1.8443492468732292114663773247580
 %% @end group
 %% @end example
 %%

--- a/inst/@sym/ellipticE.m
+++ b/inst/@sym/ellipticE.m
@@ -1,4 +1,4 @@
-%% Copyright (C) 2016 Lagu
+%% Copyright (C) 2016-2017 Lagu
 %% Copyright (C) 2017 Colin B. Macdonald
 %%
 %% This file is part of OctSymPy.

--- a/inst/@sym/ellipticE.m
+++ b/inst/@sym/ellipticE.m
@@ -77,6 +77,10 @@
 %%   @result{} ans =  1.8443
 %% @end group
 %% @end example
+%%
+%% There are other conventions for the inputs of elliptic integrals,
+%% @pxref{@@sym/ellipticF}.
+%%
 %% @seealso{@@sym/ellipke, @@sym/ellipticK, @@sym/ellipticPi}
 %% @end defmethod
 

--- a/inst/@sym/ellipticE.m
+++ b/inst/@sym/ellipticE.m
@@ -1,0 +1,101 @@
+%% Copyright (C) 2016 Lagu
+%% Copyright (C) 2017 Colin B. Macdonald
+%%
+%% This file is part of OctSymPy.
+%%
+%% OctSymPy is free software; you can redistribute it and/or modify
+%% it under the terms of the GNU General Public License as published
+%% by the Free Software Foundation; either version 3 of the License,
+%% or (at your option) any later version.
+%%
+%% This software is distributed in the hope that it will be useful,
+%% but WITHOUT ANY WARRANTY; without even the implied warranty
+%% of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See
+%% the GNU General Public License for more details.
+%%
+%% You should have received a copy of the GNU General Public
+%% License along with this software; see the file COPYING.
+%% If not, see <http://www.gnu.org/licenses/>.
+
+%% -*- texinfo -*-
+%% @documentencoding UTF-8
+%% @defmethod @@sym ellipticE (@var{m})
+%% @defmethodx @@sym ellipticE (@var{phi}, @var{m})
+%% Complete and incomplete elliptic integrals of the second kind.
+%%
+%% Incomplete elliptic integral of the second kind:
+%% @example
+%% @group
+%% syms phi m
+%% ellipticE (phi, m)
+%%   @result{} ans = (sym) E(φ│m)
+%% @end group
+%%
+%% @group
+%% rewrite (ans, 'Integral')         % doctest: +SKIP
+%%   @result{} ans = (sym)
+%%       φ
+%%       ⌠
+%%       ⎮    _________________
+%%       ⎮   ╱        2
+%%       ⎮ ╲╱  - m⋅sin (α) + 1  dα
+%%       ⌡
+%%       0
+%% @end group
+%%
+%% @group
+%% double (ellipticE (sym (1), sym (1)/10))
+%%   @result{} ans =  0.98621
+%% @end group
+%% @end example
+%%
+%% Complete elliptic integral of the second kind:
+%% @example
+%% @group
+%% ellipticE (m)
+%%   @result{} ans = (sym) E(m)
+%% @end group
+%%
+%% @group
+%% rewrite (ans, 'Integral')         % doctest: +SKIP
+%%   @result{} ans = (sym)
+%%       π
+%%       ─
+%%       2
+%%       ⌠
+%%       ⎮    _________________
+%%       ⎮   ╱        2
+%%       ⎮ ╲╱  - m⋅sin (α) + 1  dα
+%%       ⌡
+%%       0
+%% @end group
+%%
+%% @group
+%% double (ellipticE (sym (-pi)/4))
+%%   @result{} ans =  1.8443
+%% @end group
+%% @end example
+%% @seealso{@@sym/ellipticK, ellipke}
+%% @end defmethod
+
+
+function y = ellipticE(phi, m)
+
+  if (nargin == 1)
+    m = phi;
+    phi = sym (pi)/2;
+  elseif (nargin == 2)
+    % no-op
+  else
+    print_usage ();
+  end
+
+  y = elementwise_op ('elliptic_e', sym (phi), sym (m));
+
+end
+
+
+%!assert (double (ellipticE (sym (-105)/10)), 3.70961391, 10e-9)
+%!assert (double (ellipticE (sym (-pi)/4)), 1.844349247, 10e-10)
+%!assert (double (ellipticE (sym (0))), 1.570796327, 10e-10)
+%!assert (double (ellipticE (sym (1))), 1, 10e-1)

--- a/inst/@sym/ellipticF.m
+++ b/inst/@sym/ellipticF.m
@@ -71,3 +71,11 @@ end
 %!assert (double (ellipticF (sym (pi)/4, sym (-pi))), 0.6485970495, 10e-11)
 %!assert (double (ellipticF (sym (1), sym (-1))), 0.8963937895, 10e-11)
 %!assert (double (ellipticF (sym (pi)/6, sym (0))), 0.5235987756, 10e-11)
+
+%!test
+%! % compare to Maple
+%! us = vpa (ellipticF (sym(11)/10, sym(9)/4), 40);
+%! % > evalf(EllipticF(sin(11/10), sqrt(9/4)), 40);
+%! maple = vpa ('1.206444996991058996424988192917728014427', 40) - ...
+%!         vpa ('0.8157358125823472313001683083685348517476j', 40);
+%! assert (abs (double (maple - us)), 0, 1e-39)

--- a/inst/@sym/ellipticF.m
+++ b/inst/@sym/ellipticF.m
@@ -22,7 +22,8 @@
 %% @defmethod @@sym ellipticF (@var{phi}, @var{m})
 %% Incomplete elliptic integral of the first kind.
 %%
-%% Example with amplitude @var{phi} and parameter @var{m}:
+%% The incomplete elliptic integral of the first kind with
+%% amplitude @var{phi} and parameter @var{m} is given by:
 %% @example
 %% @group
 %% syms phi m

--- a/inst/@sym/ellipticF.m
+++ b/inst/@sym/ellipticF.m
@@ -44,9 +44,13 @@
 %%       ⌡
 %%       0
 %% @end group
+%% @end example
+%%
+%% Example:
+%% @example
 %% @group
-%% double (ellipticF (sym (1), sym (-1)))
-%%   @result{} ans =  0.89639
+%% vpa (ellipticF (sym (1), sym (-1)))
+%%   @result{} (sym) 0.89639378946289458637047451642060
 %% @end group
 %% @end example
 %%

--- a/inst/@sym/ellipticF.m
+++ b/inst/@sym/ellipticF.m
@@ -49,7 +49,38 @@
 %% @end group
 %% @end example
 %%
-%% @seealso{@@sym/ellipticE, @@sym/ellipticPi}
+%% For the complete elliptic integral (of the first kind), @pxref{@@sym/ellipticK}.
+%%
+%% @strong{Note:}
+%% this function (and other elliptic integrals in the Symbolic package)
+%% follow the Abramowitz and Stegun convention for the ``parameter''
+%% @iftex
+%% @math{m}.
+%% @end iftex
+%% @ifnottex
+%% @var{m}.
+%% @end ifnottex
+%% Other sources and software may use different conventions, such as
+%% @iftex
+%% the ``elliptic modulus'' @math{k}
+%% or the ``modular angle'' @math{\alpha},
+%% related by @math{m = k^2 = \sin^2(\alpha)}.
+%% @end iftex
+%% @ifnottex
+%% the ``elliptic modulus'' k
+%% or the ``modular angle'' α,
+%% related by @code{@var{m} = k^2 = sin^2(α)}.
+%% @end ifnottex
+%% They may define these functions in terms of the sine of the amplitude
+%% @iftex
+%% @math{\sin(\phi)}.
+%% @end iftex
+%% @ifnottex
+%% @code{sin(@var{phi})}.
+%% @end ifnottex
+%% For example, Maple uses the elliptic modulus and the sine of the amplitude.
+%%
+%% @seealso{@@sym/ellipticK, @@sym/ellipticE, @@sym/ellipticPi}
 %% @end defmethod
 
 

--- a/inst/@sym/ellipticF.m
+++ b/inst/@sym/ellipticF.m
@@ -1,4 +1,4 @@
-%% Copyright (C) 2016 Lagu
+%% Copyright (C) 2016-2017 Lagu
 %%
 %% This file is part of OctSymPy.
 %%

--- a/inst/@sym/ellipticF.m
+++ b/inst/@sym/ellipticF.m
@@ -21,7 +21,7 @@
 %% @defmethod @@sym ellipticF (@var{phi}, @var{m})
 %% Incomplete elliptic integral of the first kind.
 %%
-%% Example:
+%% Example with amplitude @var{phi} and parameter @var{m}:
 %% @example
 %% @group
 %% syms phi m

--- a/inst/@sym/ellipticF.m
+++ b/inst/@sym/ellipticF.m
@@ -52,9 +52,9 @@
 %% @end defmethod
 
 
-function y = ellipticF(phi, m)
+function y = ellipticF (phi, m)
 
-  if nargin ~= 2
+  if (nargin ~= 2)
     print_usage ();
   end
 

--- a/inst/@sym/ellipticF.m
+++ b/inst/@sym/ellipticF.m
@@ -48,7 +48,7 @@
 %% @end group
 %% @end example
 %%
-%% @seealso{@@sym/ellipticPi}
+%% @seealso{@@sym/ellipticE, @@sym/ellipticPi}
 %% @end defmethod
 
 
@@ -58,11 +58,14 @@ function y = ellipticF(phi, m)
     print_usage ();
   end
 
-% y = ellipticPi (0, phi, m);
-  y = elementwise_op ('elliptic_f', phi, m);
+  % y = ellipticPi (0, phi, m);
+  y = elementwise_op ('elliptic_f', sym (phi), sym (m));
 
 end
 
+
+%!error <Invalid> ellipticF (sym(1))
+%!error <Invalid> ellipticF (sym(1), 2, 3)
 
 %!assert (double (ellipticF (sym (pi)/3, sym (-105)/10)), 0.6184459461, 10e-11)
 %!assert (double (ellipticF (sym (pi)/4, sym (-pi))), 0.6485970495, 10e-11)

--- a/inst/@sym/ellipticF.m
+++ b/inst/@sym/ellipticF.m
@@ -1,4 +1,5 @@
 %% Copyright (C) 2016-2017 Lagu
+%% Copyright (C) 2017 Colin B. Macdonald
 %%
 %% This file is part of OctSymPy.
 %%

--- a/inst/@sym/ellipticF.m
+++ b/inst/@sym/ellipticF.m
@@ -1,0 +1,70 @@
+%% Copyright (C) 2016 Lagu
+%%
+%% This file is part of OctSymPy.
+%%
+%% OctSymPy is free software; you can redistribute it and/or modify
+%% it under the terms of the GNU General Public License as published
+%% by the Free Software Foundation; either version 3 of the License,
+%% or (at your option) any later version.
+%%
+%% This software is distributed in the hope that it will be useful,
+%% but WITHOUT ANY WARRANTY; without even the implied warranty
+%% of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See
+%% the GNU General Public License for more details.
+%%
+%% You should have received a copy of the GNU General Public
+%% License along with this software; see the file COPYING.
+%% If not, see <http://www.gnu.org/licenses/>.
+
+%% -*- texinfo -*-
+%% @documentencoding UTF-8
+%% @defmethod @@sym ellipticF (@var{phi}, @var{m})
+%% Incomplete elliptic integral of the first kind.
+%%
+%% Example:
+%% @example
+%% @group
+%% syms phi m
+%% ellipticF (phi, m)
+%%   @result{} ans = (sym) F(φ│m)
+%% @end group
+%%
+%% @group
+%% rewrite (ans, 'Integral')         % doctest: +SKIP
+%%   @result{} ans = (sym)
+%%       φ
+%%       ⌠
+%%       ⎮          1
+%%       ⎮ ──────────────────── dα
+%%       ⎮    _________________
+%%       ⎮   ╱        2
+%%       ⎮ ╲╱  - m⋅sin (α) + 1
+%%       ⌡
+%%       0
+%% @end group
+%% @group
+%% double (ellipticF (sym (1), sym (-1)))
+%%   @result{} ans =  0.89639
+%% @end group
+%% @end example
+%%
+%% @seealso{@@sym/ellipticPi}
+%% @end defmethod
+
+
+function y = ellipticF(phi, m)
+
+  if nargin ~= 2
+    print_usage ();
+  end
+
+% y = ellipticPi (0, phi, m);
+  y = elementwise_op ('elliptic_f', phi, m);
+
+end
+
+
+%!assert (double (ellipticF (sym (pi)/3, sym (-105)/10)), 0.6184459461, 10e-11)
+%!assert (double (ellipticF (sym (pi)/4, sym (-pi))), 0.6485970495, 10e-11)
+%!assert (double (ellipticF (sym (1), sym (-1))), 0.8963937895, 10e-11)
+%!assert (double (ellipticF (sym (pi)/6, sym (0))), 0.5235987756, 10e-11)

--- a/inst/@sym/ellipticK.m
+++ b/inst/@sym/ellipticK.m
@@ -52,23 +52,8 @@
 %% @end group
 %% @end example
 %%
-%% @strong{Note:}
-%% this function (and other elliptic integrals in the Symbolic package)
-%% follow the Abramowitz and Stegun convention for the parameter
-%% @iftex
-%% @math{m}.
-%% @end iftex
-%% @ifnottex
-%% @var{m}.
-%% @end ifnottex
-%% Other software may use other conventions (e.g.,
-%% Maple uses the elliptic modulus
-%% @iftex
-%% @math{k}, related by @math{m = k^2}).
-%% @end iftex
-%% @ifnottex
-%% @var{k}, related by @code{@var{m} = @var{k}^2}).
-%% @end ifnottex
+%% There are other conventions for the inputs of elliptic integrals,
+%% @pxref{@@sym/ellipticF}.
 %%
 %% @seealso{@@sym/ellipke, @@sym/ellipticF, @@sym/ellipticE, @@sym/ellipticPi}
 %% @end defmethod

--- a/inst/@sym/ellipticK.m
+++ b/inst/@sym/ellipticK.m
@@ -111,8 +111,9 @@ end
 %! assert (double (ellipticE (ms)), E, -1e-15)
 
 %!test
-%! % compare to Maple: evalf(EllipticK(sqrt(7)), 40);
+%! % compare to Maple
+%! us = vpa (ellipticK (sym (7)), 40);
+%! % > evalf(EllipticK(sqrt(7)), 40);
 %! maple = vpa ('0.6168027921799632674669917683443602673441', 40) - ...
 %!         vpa ('0.9114898734184488922164103102629560336918j', 40);
-%! us = vpa (ellipticK (sym (7)), 40);
 %! assert (abs (double (maple - us)), 0, 1e-39)

--- a/inst/@sym/ellipticK.m
+++ b/inst/@sym/ellipticK.m
@@ -22,7 +22,8 @@
 %% @defmethod @@sym ellipticK (@var{m})
 %% Complete elliptic integral of the first kind.
 %%
-%% Example with parameter @var{m}:
+%% The complete elliptic integral of the first kind
+%% with parameter @var{m} is defined by:
 %% @example
 %% @group
 %% syms m
@@ -44,6 +45,17 @@
 %%       ⎮ ╲╱  - m⋅sin (α) + 1
 %%       ⌡
 %%       0
+%% @end group
+%% @end example
+%%
+%% Examples:
+%% @example
+%% @group
+%% diff (ellipticK (m), m)
+%%   @result{} (sym)
+%%       -(-m + 1)⋅K(m) + E(m)
+%%       ─────────────────────
+%%            2⋅m⋅(-m + 1)
 %% @end group
 %%
 %% @group

--- a/inst/@sym/ellipticK.m
+++ b/inst/@sym/ellipticK.m
@@ -1,0 +1,91 @@
+%% Copyright (C) 2016 Lagu
+%% Copyright (C) 2017 Colin B. Macdonald
+%%
+%% This file is part of OctSymPy.
+%%
+%% OctSymPy is free software; you can redistribute it and/or modify
+%% it under the terms of the GNU General Public License as published
+%% by the Free Software Foundation; either version 3 of the License,
+%% or (at your option) any later version.
+%%
+%% This software is distributed in the hope that it will be useful,
+%% but WITHOUT ANY WARRANTY; without even the implied warranty
+%% of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See
+%% the GNU General Public License for more details.
+%%
+%% You should have received a copy of the GNU General Public
+%% License along with this software; see the file COPYING.
+%% If not, see <http://www.gnu.org/licenses/>.
+
+%% -*- texinfo -*-
+%% @documentencoding UTF-8
+%% @defmethod @@sym ellipticK (@var{m})
+%% Complete elliptic integral of the first kind.
+%%
+%% Example:
+%% @example
+%% @group
+%% syms m
+%% ellipticK (m)
+%%   @result{} ans = (sym) K(m)
+%% @end group
+%%
+%% @group
+%% rewrite (ans, 'Integral')         % doctest: +SKIP
+%%   @result{} ans = (sym)
+%%       π
+%%       ─
+%%       2
+%%       ⌠
+%%       ⎮          1
+%%       ⎮ ──────────────────── dα
+%%       ⎮    _________________
+%%       ⎮   ╱        2
+%%       ⎮ ╲╱  - m⋅sin (α) + 1
+%%       ⌡
+%%       0
+%% @end group
+%%
+%% @group
+%% double (ellipticK (sym (pi)/4))
+%%   @result{} ans =  2.2253
+%% @end group
+%% @end example
+%%
+%% @seealso{@@sym/ellipticF, @@sym/ellipticPi, ellipKE}
+%% @end defmethod
+
+
+function y = ellipticK(m)
+  if nargin > 1
+    print_usage();
+  end
+
+% y = ellipticF (sym (pi)/2, m);
+  y = elementwise_op ('elliptic_k', m);
+
+end
+
+
+%!assert (isequal (ellipticK (sym (0)), sym (pi)/2))
+%!assert (isequal (ellipticK (sym (-inf)), sym (0)))
+
+%!assert (double (ellipticK (sym (1)/2)), 1.854074677, 10e-10)
+%!assert (double (ellipticK (sym (pi)/4)), 2.225253684, 10e-10)
+%!assert (double (ellipticK (sym (-55)/10)), 0.9324665884, 10e-11)
+
+%!test
+%! % compare to double ellipke
+%! m = 1/5;
+%! ms = sym(1)/5;
+%! [K, E] = ellipke (m);
+%! assert (double (ellipticK (ms)), K, -1e-15)
+%! assert (double (ellipticE (ms)), E, -1e-15)
+
+%!test
+%! % compare to double ellipke
+%! m = -10.3;
+%! ms = -sym(103)/10;
+%! [K, E] = ellipke (m);
+%! assert (double (ellipticK (ms)), K, -1e-15)
+%! assert (double (ellipticE (ms)), E, -1e-15)

--- a/inst/@sym/ellipticK.m
+++ b/inst/@sym/ellipticK.m
@@ -52,7 +52,7 @@
 %% @end group
 %% @end example
 %%
-%% @seealso{@@sym/ellipticF, @@sym/ellipticPi, ellipKE}
+%% @seealso{@@sym/ellipke, @@sym/ellipticF, @@sym/ellipticE, @@sym/ellipticPi}
 %% @end defmethod
 
 
@@ -61,11 +61,13 @@ function y = ellipticK(m)
     print_usage();
   end
 
-% y = ellipticF (sym (pi)/2, m);
+  % y = ellipticF (sym (pi)/2, m);
   y = elementwise_op ('elliptic_k', m);
 
 end
 
+
+%!error <Invalid> ellipticK (sym(1), 2)
 
 %!assert (isequal (ellipticK (sym (0)), sym (pi)/2))
 %!assert (isequal (ellipticK (sym (-inf)), sym (0)))

--- a/inst/@sym/ellipticK.m
+++ b/inst/@sym/ellipticK.m
@@ -1,4 +1,4 @@
-%% Copyright (C) 2016 Lagu
+%% Copyright (C) 2016-2017 Lagu
 %% Copyright (C) 2017 Colin B. Macdonald
 %%
 %% This file is part of OctSymPy.

--- a/inst/@sym/ellipticK.m
+++ b/inst/@sym/ellipticK.m
@@ -109,3 +109,10 @@ end
 %! [K, E] = ellipke (m);
 %! assert (double (ellipticK (ms)), K, -1e-15)
 %! assert (double (ellipticE (ms)), E, -1e-15)
+
+%!test
+%! % compare to Maple: evalf(EllipticK(sqrt(7)), 40);
+%! maple = vpa ('0.6168027921799632674669917683443602673441', 40) - ...
+%!         vpa ('0.9114898734184488922164103102629560336918j', 40);
+%! us = vpa (ellipticK (sym (7)), 40);
+%! assert (abs (double (maple - us)), 0, 1e-39)

--- a/inst/@sym/ellipticK.m
+++ b/inst/@sym/ellipticK.m
@@ -74,9 +74,9 @@
 %% @end defmethod
 
 
-function y = ellipticK(m)
-  if nargin > 1
-    print_usage();
+function y = ellipticK (m)
+  if (nargin > 1)
+    print_usage ();
   end
 
   % y = ellipticF (sym (pi)/2, m);

--- a/inst/@sym/ellipticK.m
+++ b/inst/@sym/ellipticK.m
@@ -22,7 +22,7 @@
 %% @defmethod @@sym ellipticK (@var{m})
 %% Complete elliptic integral of the first kind.
 %%
-%% Example:
+%% Example with parameter @var{m}:
 %% @example
 %% @group
 %% syms m

--- a/inst/@sym/ellipticK.m
+++ b/inst/@sym/ellipticK.m
@@ -59,8 +59,8 @@
 %% @end group
 %%
 %% @group
-%% double (ellipticK (sym (pi)/4))
-%%   @result{} ans =  2.2253
+%% vpa (ellipticK (sym (pi)/4))
+%%   @result{} (sym) 2.2252536839853959577044373301346
 %% @end group
 %% @end example
 %%

--- a/inst/@sym/ellipticK.m
+++ b/inst/@sym/ellipticK.m
@@ -52,6 +52,24 @@
 %% @end group
 %% @end example
 %%
+%% @strong{Note:}
+%% this function (and other elliptic integrals in the Symbolic package)
+%% follow the Abramowitz and Stegun convention for the parameter
+%% @iftex
+%% @math{m}.
+%% @end iftex
+%% @ifnottex
+%% @var{m}.
+%% @end ifnottex
+%% Other software may use other conventions (e.g.,
+%% Maple uses the elliptic modulus
+%% @iftex
+%% @math{k}, related by @math{m = k^2}).
+%% @end iftex
+%% @ifnottex
+%% @var{k}, related by @code{@var{m} = @var{k}^2}).
+%% @end ifnottex
+%%
 %% @seealso{@@sym/ellipke, @@sym/ellipticF, @@sym/ellipticE, @@sym/ellipticPi}
 %% @end defmethod
 

--- a/inst/@sym/ellipticPi.m
+++ b/inst/@sym/ellipticPi.m
@@ -18,7 +18,7 @@
 
 %% -*- texinfo -*-
 %% @documentencoding UTF-8
-%% @defmethod @@sym y = ellipticPi (@var{n}, @var{m})
+%% @defmethod  @@sym y = ellipticPi (@var{n}, @var{m})
 %% @defmethodx @@sym y = ellipticPi (@var{n}, @var{phi}, @var{m})
 %% Complete and incomplete elliptic integrals of the third kind.
 %%
@@ -27,6 +27,7 @@
 %% @group
 %% syms n phi m
 %% ellipticPi (n, phi, m)
+%%   @result{} (sym) Π(n; φ│m)
 %% @end group
 %%
 %% @group
@@ -42,11 +43,13 @@
 %%       ⌡
 %%       0
 %% @end group
+%%
 %% @group
 %% double (ellipticPi (sym (1), sym (1)/10, sym (1)/2))
 %%   @result{} ans =  0.10042
 %% @end group
 %% @end example
+%%
 %% Complete elliptic integral of the third kind:
 %% @example
 %% @group
@@ -70,12 +73,14 @@
 %%       ⌡
 %%       0
 %% @end group
+%%
 %% @group
 %% double (ellipticPi (sym (pi)/4, sym (pi)/8))
 %%   @result{} ans =  4.0068
 %% @end group
 %% @end example
 %%
+%% @seealso{@@sym/ellipticF, @@sym/ellipticK, @@sym/ellipticE}
 %% @end defmethod
 
 
@@ -92,6 +97,9 @@ function y = ellipticPi(n, phi, m)
 
 end
 
+
+%!error <Invalid> ellipticPi (sym (1))
+%!error <Invalid> ellipticPi (sym (1), 2, 3, 4)
 
 %!assert (double (ellipticPi (sym (-23)/10, sym (pi)/4, 0)), 0.5876852228, 10e-11)
 %!assert (double (ellipticPi (sym (1)/3, sym (pi)/3, sym (1)/2)), 1.285032276, 10e-11)

--- a/inst/@sym/ellipticPi.m
+++ b/inst/@sym/ellipticPi.m
@@ -1,0 +1,99 @@
+%% Copyright (C) 2016 Lagu
+%%
+%% This file is part of OctSymPy.
+%%
+%% OctSymPy is free software; you can redistribute it and/or modify
+%% it under the terms of the GNU General Public License as published
+%% by the Free Software Foundation; either version 3 of the License,
+%% or (at your option) any later version.
+%%
+%% This software is distributed in the hope that it will be useful,
+%% but WITHOUT ANY WARRANTY; without even the implied warranty
+%% of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See
+%% the GNU General Public License for more details.
+%%
+%% You should have received a copy of the GNU General Public
+%% License along with this software; see the file COPYING.
+%% If not, see <http://www.gnu.org/licenses/>.
+
+%% -*- texinfo -*-
+%% @documentencoding UTF-8
+%% @defmethod @@sym y = ellipticPi (@var{n}, @var{m})
+%% @defmethodx @@sym y = ellipticPi (@var{n}, @var{phi}, @var{m})
+%% Complete and incomplete elliptic integrals of the third kind.
+%%
+%% Incomplete elliptic integral of the third kind:
+%% @example
+%% @group
+%% syms n phi m
+%% ellipticPi (n, phi, m)
+%% @end group
+%%
+%% @group
+%% rewrite (ans, 'Integral')         % doctest: +SKIP
+%%   @result{} ans = (sym)
+%%       φ
+%%       ⌠
+%%       ⎮                   1
+%%       ⎮ ────────────────────────────────────── dα
+%%       ⎮    _________________
+%%       ⎮   ╱        2         ⎛       2       ⎞
+%%       ⎮ ╲╱  - m⋅sin (α) + 1 ⋅⎝- n⋅sin (α) + 1⎠
+%%       ⌡
+%%       0
+%% @end group
+%% @group
+%% double (ellipticPi (sym (1), sym (1)/10, sym (1)/2))
+%%   @result{} ans =  0.10042
+%% @end group
+%% @end example
+%% Complete elliptic integral of the third kind:
+%% @example
+%% @group
+%% syms n m
+%% ellipticPi (n, m)
+%%   @result{} ans = (sym) Π(n│m)
+%% @end group
+%%
+%% @group
+%% rewrite (ans, 'Integral')         % doctest: +SKIP
+%%   @result{} ans = (sym)
+%%       π
+%%       ─
+%%       2
+%%       ⌠
+%%       ⎮                   1
+%%       ⎮ ────────────────────────────────────── dα
+%%       ⎮    _________________
+%%       ⎮   ╱        2         ⎛       2       ⎞
+%%       ⎮ ╲╱  - m⋅sin (α) + 1 ⋅⎝- n⋅sin (α) + 1⎠
+%%       ⌡
+%%       0
+%% @end group
+%% @group
+%% double (ellipticPi (sym (pi)/4, sym (pi)/8))
+%%   @result{} ans =  4.0068
+%% @end group
+%% @end example
+%%
+%% @end defmethod
+
+
+function y = ellipticPi(n, phi, m)
+
+  switch nargin
+    case 2
+      y = ellipticPi (n, sym (pi)/2, phi);
+    case 3
+      y = elementwise_op ('elliptic_pi', sym (n), sym (phi), sym (m));
+    otherwise
+      print_usage();
+  end
+
+end
+
+
+%!assert (double (ellipticPi (sym (-23)/10, sym (pi)/4, 0)), 0.5876852228, 10e-11)
+%!assert (double (ellipticPi (sym (1)/3, sym (pi)/3, sym (1)/2)), 1.285032276, 10e-11)
+%!xtest assert (double (ellipticPi (sym (-1), 0, sym (1))), 0)
+%!assert (double (ellipticPi (sym (2), sym (pi)/6, sym (2))), 0.7507322117, 10e-11)

--- a/inst/@sym/ellipticPi.m
+++ b/inst/@sym/ellipticPi.m
@@ -18,16 +18,17 @@
 
 %% -*- texinfo -*-
 %% @documentencoding UTF-8
-%% @defmethod  @@sym y = ellipticPi (@var{n}, @var{m})
-%% @defmethodx @@sym y = ellipticPi (@var{n}, @var{phi}, @var{m})
+%% @defmethod  @@sym y = ellipticPi (@var{nu}, @var{m})
+%% @defmethodx @@sym y = ellipticPi (@var{nu}, @var{phi}, @var{m})
 %% Complete and incomplete elliptic integrals of the third kind.
 %%
-%% Incomplete elliptic integral of the third kind:
+%% Incomplete elliptic integral of the third kind with characteristic
+%% @var{nu}, amplitude @var{phi} and parameter @var{m}:
 %% @example
 %% @group
-%% syms n phi m
-%% ellipticPi (n, phi, m)
-%%   @result{} (sym) Π(n; φ│m)
+%% syms nu phi m
+%% ellipticPi (nu, phi, m)
+%%   @result{} (sym) Π(ν; φ│m)
 %% @end group
 %%
 %% @group
@@ -39,7 +40,7 @@
 %%       ⎮ ────────────────────────────────────── dα
 %%       ⎮    _________________
 %%       ⎮   ╱        2         ⎛       2       ⎞
-%%       ⎮ ╲╱  - m⋅sin (α) + 1 ⋅⎝- n⋅sin (α) + 1⎠
+%%       ⎮ ╲╱  - m⋅sin (α) + 1 ⋅⎝- ν⋅sin (α) + 1⎠
 %%       ⌡
 %%       0
 %% @end group
@@ -50,12 +51,12 @@
 %% @end group
 %% @end example
 %%
-%% Complete elliptic integral of the third kind:
+%% Complete elliptic integral of the third kind with characteristic
+%% @var{nu} and parameter @var{m}:
 %% @example
 %% @group
-%% syms n m
-%% ellipticPi (n, m)
-%%   @result{} ans = (sym) Π(n│m)
+%% ellipticPi (nu, m)
+%%   @result{} ans = (sym) Π(ν│m)
 %% @end group
 %%
 %% @group
@@ -69,7 +70,7 @@
 %%       ⎮ ────────────────────────────────────── dα
 %%       ⎮    _________________
 %%       ⎮   ╱        2         ⎛       2       ⎞
-%%       ⎮ ╲╱  - m⋅sin (α) + 1 ⋅⎝- n⋅sin (α) + 1⎠
+%%       ⎮ ╲╱  - m⋅sin (α) + 1 ⋅⎝- ν⋅sin (α) + 1⎠
 %%       ⌡
 %%       0
 %% @end group
@@ -84,13 +85,13 @@
 %% @end defmethod
 
 
-function y = ellipticPi (n, phi, m)
+function y = ellipticPi (nu, phi, m)
 
   switch nargin
     case 2
-      y = ellipticPi (n, sym (pi)/2, phi);
+      y = ellipticPi (nu, sym (pi)/2, phi);
     case 3
-      y = elementwise_op ('elliptic_pi', sym (n), sym (phi), sym (m));
+      y = elementwise_op ('elliptic_pi', sym (nu), sym (phi), sym (m));
     otherwise
       print_usage();
   end

--- a/inst/@sym/ellipticPi.m
+++ b/inst/@sym/ellipticPi.m
@@ -84,7 +84,7 @@
 %% @end defmethod
 
 
-function y = ellipticPi(n, phi, m)
+function y = ellipticPi (n, phi, m)
 
   switch nargin
     case 2
@@ -103,5 +103,8 @@ end
 
 %!assert (double (ellipticPi (sym (-23)/10, sym (pi)/4, 0)), 0.5876852228, 10e-11)
 %!assert (double (ellipticPi (sym (1)/3, sym (pi)/3, sym (1)/2)), 1.285032276, 10e-11)
-%!xtest assert (double (ellipticPi (sym (-1), 0, sym (1))), 0)
 %!assert (double (ellipticPi (sym (2), sym (pi)/6, sym (2))), 0.7507322117, 10e-11)
+
+%!xtest
+%! % FIXME: search/report upstream
+%! assert (double (ellipticPi (sym (-1), 0, sym (1))), 0)

--- a/inst/@sym/ellipticPi.m
+++ b/inst/@sym/ellipticPi.m
@@ -109,3 +109,19 @@ end
 %!xtest
 %! % FIXME: search/report upstream
 %! assert (double (ellipticPi (sym (-1), 0, sym (1))), 0)
+
+%!test
+%! % compare to Maple, complete
+%! us = vpa (ellipticPi (sym(1)/6, sym(4)/3), 40);
+%! % > evalf(EllipticPi(sin(1/6), sqrt(4/3)), 40);
+%! maple = vpa ('2.019271696236161760696477679310987869058', 40) - ...
+%!         vpa ('1.708165765120289929280805062355360570830j', 40);
+%! assert (abs (double (maple - us)), 0, 2e-39)
+
+%!test
+%! % compare to Maple, incomplete
+%! us = vpa (ellipticPi (sym(8)/7, sym(4)/3, sym(2)/7), 40);
+%! % > evalf(EllipticPi(sin(4/3), 8/7, sqrt(2/7)), 40);
+%! maple = vpa ('2.089415796799294830305265090302275542033', 40) - ...
+%!         vpa ('4.798862045930802761256228043192491271947j', 40);
+%! assert (abs (double (maple - us)), 0, 6e-39)

--- a/inst/@sym/ellipticPi.m
+++ b/inst/@sym/ellipticPi.m
@@ -1,4 +1,4 @@
-%% Copyright (C) 2016 Lagu
+%% Copyright (C) 2016-2017 Lagu
 %%
 %% This file is part of OctSymPy.
 %%

--- a/inst/@sym/ellipticPi.m
+++ b/inst/@sym/ellipticPi.m
@@ -82,6 +82,9 @@
 %% @end group
 %% @end example
 %%
+%% There are other conventions for the inputs of elliptic integrals,
+%% @pxref{@@sym/ellipticF}.
+%%
 %% @seealso{@@sym/ellipticF, @@sym/ellipticK, @@sym/ellipticE}
 %% @end defmethod
 

--- a/inst/@sym/ellipticPi.m
+++ b/inst/@sym/ellipticPi.m
@@ -45,11 +45,6 @@
 %%       ⌡
 %%       0
 %% @end group
-%%
-%% @group
-%% double (ellipticPi (sym (1), sym (1)/10, sym (1)/2))
-%%   @result{} ans =  0.10042
-%% @end group
 %% @end example
 %%
 %% Complete elliptic integral of the third kind with characteristic
@@ -75,10 +70,18 @@
 %%       ⌡
 %%       0
 %% @end group
+%% @end example
+%%
+%% Examples:
+%% @example
+%% @group
+%% vpa (ellipticPi (sym (1), sym (1)/10, sym (1)/2))
+%%   @result{} (sym) 0.10041852861527457424263837477419
+%% @end group
 %%
 %% @group
-%% double (ellipticPi (sym (pi)/4, sym (pi)/8))
-%%   @result{} ans =  4.0068
+%% vpa (ellipticPi (sym (pi)/4, sym (pi)/8))
+%%   @result{} (sym) 4.0068172051461721205075153294257
 %% @end group
 %% @end example
 %%

--- a/inst/@sym/ellipticPi.m
+++ b/inst/@sym/ellipticPi.m
@@ -1,4 +1,5 @@
 %% Copyright (C) 2016-2017 Lagu
+%% Copyright (C) 2017 Colin B. Macdonald
 %%
 %% This file is part of OctSymPy.
 %%


### PR DESCRIPTION
- [x] start with code from PR #676 by @latot 
- [x] more tests
- [x] fix `CK` and `CPi` which were incorrect.
- [x] moar tests!
   - [x] compare vpa output to Maple for `ellipticK`.
   - [x] compare vpa output to Maple for others
- [x] Add some note to the documentation about the various different forms these can take.
   - [x] should we do this in each function or xref somehow?
- [x] ~~double-check the rewrite integral stuff.~~ (postpone will do upstream first)

