### PR TITLE
subsasgn: fix to define a matrix while also growing it

### DIFF
--- a/inst/@sym/private/mat_rclist_asgn.m
+++ b/inst/@sym/private/mat_rclist_asgn.m
@@ -33,8 +33,6 @@
 %%
 %% @end defun
 
-%% Author: Colin B. Macdonald
-%% Keywords: symbolic
 
 function z = mat_rclist_asgn(A, r, c, B)
 

--- a/inst/@sym/private/mat_rclist_asgn.m
+++ b/inst/@sym/private/mat_rclist_asgn.m
@@ -1,4 +1,4 @@
-%% Copyright (C) 2014, 2016 Colin B. Macdonald
+%% Copyright (C) 2014, 2016-2017 Colin B. Macdonald
 %%
 %% This file is part of OctSymPy.
 %%
@@ -58,7 +58,7 @@ function z = mat_rclist_asgn(A, r, c, B)
           '    B = sp.Matrix([[B]])'
           'BT = B.T'
           '# copy of A, expanded and padded with zeros'
-          'if not A.is_Matrix:'
+          'if not A or not A.is_Matrix:'
           '    n = max( max(r)+1, 1 )'
           '    m = max( max(c)+1, 1 )'
           'else:'

--- a/inst/@sym/subsasgn.m
+++ b/inst/@sym/subsasgn.m
@@ -163,6 +163,20 @@ end
 %! assert(isequal( a, b ))
 
 %!test
+%! % grow from nothing
+%! clear a
+%! a(3) = sym (1);
+%! b = sym ([0 0 1]);
+%! assert (isequal (a, b))
+
+%!test
+%! % grow from nothing, 2D
+%! clear a
+%! a(2, 3) = sym (1);
+%! b = sym ([0 0 0; 0 0 1;]);
+%! assert (isequal (a, b))
+
+%!test
 %! % linear indices of 2D
 %! b = 1:4; b = [b; 2*b; 3*b];
 %! a = sym(b);

--- a/inst/@sym/subsasgn.m
+++ b/inst/@sym/subsasgn.m
@@ -56,6 +56,7 @@
 %% @seealso{@@sym/subsref, @@sym/subindex, @@sym/end, symfun}
 %% @end deftypeop
 
+
 function out = subsasgn (val, idx, rhs)
 
   switch idx.type
@@ -76,7 +77,7 @@ function out = subsasgn (val, idx, rhs)
         all_Symbols = python_cmd (cmd, idx.subs);
       end
       if (all_syms && all_Symbols)
-	%% Make a symfun
+        %% Make a symfun
         if (~isa(rhs, 'sym'))
           % rhs is, e.g., a double, then we call the constructor
           rhs = sym(rhs);
@@ -91,12 +92,12 @@ function out = subsasgn (val, idx, rhs)
             idx.subs{i} = double(idx.subs{i});
           end
         end
-	for i = 1:length(idx.subs)
+        for i = 1:length(idx.subs)
           if (~ is_valid_index(idx.subs{i}))
             error('OctSymPy:subsref:invalidIndices', ...
                   'invalid indices: should be integers or boolean');
           end
-	end
+        end
         out = mat_replace(val, idx.subs, sym(rhs));
       end
 


### PR DESCRIPTION
Support "clear a; a(3) = sym(1)" which should pad with zeros.
Inspired by upstream https://savannah.gnu.org/bugs/index.php?50202
