### PR TITLE
Convert int/long to int64

### DIFF
--- a/inst/private/check_and_convert.m
+++ b/inst/private/check_and_convert.m
@@ -1,5 +1,5 @@
 %% Copyright (C) 2016 Abhinav Tripathi
-%% Copyright (C) 2016 Colin B. Macdonald
+%% Copyright (C) 2016, 2017 Colin B. Macdonald
 %%
 %% This file is part of OctSymPy.
 %%
@@ -23,6 +23,7 @@ function obj = check_and_convert(var_pyobj)
   persistent list_or_tuple
   persistent _sym
   persistent string_types
+  persistent integer_types
   if isempty(builtins)
     builtins = pyeval("__builtins__");
     list_or_tuple = py.tuple({builtins.list, builtins.tuple});
@@ -30,6 +31,7 @@ function obj = check_and_convert(var_pyobj)
     sp = py.sympy;
     _sym = py.tuple({sp.Basic, sp.MatrixBase});
     string_types = py.six.string_types;
+    integer_types = py.six.integer_types;
   end
 
 
@@ -56,9 +58,13 @@ function obj = check_and_convert(var_pyobj)
       % make sure values are converted to sym
       s = structfun (@(t) check_and_convert (t){:}, s, 'UniformOutput', false);
       obj{i} = s;
-    elseif (py.isinstance(x, pyeval('int')))
+    elseif (py.isinstance(x, integer_types))
       if (py.isinstance(x, pyeval('bool')))
         error ('unexpected python bool')
+      end
+      if (abs (r) > intmax ('int64'))
+        error ('precision would be lost converting integer larger than %ld', ...
+               intmax ('int64'))
       end
       obj{i} = int64 (x);
     else

--- a/inst/private/check_and_convert.m
+++ b/inst/private/check_and_convert.m
@@ -62,7 +62,7 @@ function obj = check_and_convert(var_pyobj)
       if (py.isinstance(x, pyeval('bool')))
         error ('unexpected python bool')
       end
-      if (abs (r) > intmax ('int64'))
+      if (abs (double (x)) > intmax ('int64'))
         error ('precision would be lost converting integer larger than %ld', ...
                intmax ('int64'))
       end

--- a/inst/private/extractblock.m
+++ b/inst/private/extractblock.m
@@ -131,9 +131,6 @@ function r = process_item(item)
       assert(M == 1)
       % Note: is it possible to avoid converting to double first?
       r = str2double(C{2});
-      if (~ exist ('OCTAVE_VERSION', 'builtin'))
-        flintmax = 9007199254740992;
-      end
       if (abs (r) > flintmax)
         error ('precision would be lost converting integer larger than %ld', ...
                flintmax)

--- a/inst/private/extractblock.m
+++ b/inst/private/extractblock.m
@@ -1,4 +1,4 @@
-%% Copyright (C) 2014-2016 Colin B. Macdonald
+%% Copyright (C) 2014-2017 Colin B. Macdonald
 %%
 %% This file is part of OctSymPy.
 %%
@@ -129,7 +129,16 @@ function r = process_item(item)
   switch wh
     case OCTCODE_INT
       assert(M == 1)
+      % Note: is it possible to avoid converting to double first?
       r = str2double(C{2});
+      if (~ exist ('OCTAVE_VERSION', 'builtin'))
+        flintmax = 9007199254740992;
+      end
+      if (abs (r) > flintmax)
+        error ('precision would be lost converting integer larger than %ld', ...
+               flintmax)
+      end
+      r = int64 (r);
     case OCTCODE_DOUBLE
       assert(M == 1)
       r = hex2num(C{2});

--- a/inst/private/python_header.py
+++ b/inst/private/python_header.py
@@ -1,4 +1,4 @@
-# Copyright (C) 2014-2016 Colin B. Macdonald
+# Copyright (C) 2014-2017 Colin B. Macdonald
 # Free Software without warranty, GPL-3.0+: see python_header.m
 
 # In some cases this code is fed into stdin: two blank lines between
@@ -177,7 +177,7 @@ try:
             c = ET.SubElement(et, "list")
             for y in x:
                 octoutput(y, c)
-        elif isinstance(x, int):
+        elif isinstance(x, int) or (sys.version_info < (3, 0) and isinstance(x, long)):
             a = ET.SubElement(et, "item")
             f = ET.SubElement(a, "f")
             f.text = str(OCTCODE_INT)

--- a/inst/python_cmd.m
+++ b/inst/python_cmd.m
@@ -216,7 +216,9 @@ end
 
 %!test
 %! % int
-%! assert (python_cmd ('return 123456,') == 123456)
+%! r = python_cmd ('return 123456');
+%! assert (r == 123456)
+%! assert (isinteger (r))
 
 %!test
 %! % string
@@ -465,9 +467,9 @@ end
 %! if (exist ('OCTAVE_VERSION', 'builtin'))
 %! s = ['abc'; 'defgh'; '12345'];
 %! q = python_cmd ('return len(_ins)', s);
-%! assert (q, 1)
+%! assert (q == 1)
 %! q = python_cmd ('return len(_ins[0])', s);
-%! assert (q, 5)
+%! assert (q == 5)
 %! s2 = python_cmd ('return _ins[0]', s);
 %! assert (strcmp (s2, 'abc  '))
 %! end

--- a/inst/python_cmd.m
+++ b/inst/python_cmd.m
@@ -221,6 +221,12 @@ end
 %! assert (isinteger (r))
 
 %!test
+%! % long (on python2)
+%! r = python_cmd ('return 42 if sys.version_info >= (3,0) else long(42)');
+%! assert (r == 42)
+%! assert (isinteger (r))
+
+%!test
 %! % string
 %! x = 'octave';
 %! cmd = 's = _ins[0]; return s.capitalize(),';


### PR DESCRIPTION
This addresses #772.  @mtmiller, what do you think?

There might be some way to get the int64 directly instead of converting to double (maybe `sscanf`?) but I didn't make it work.  The difference between `flintmax` and `intmax('int64')` is only a few orders of magnitude so maybe its not worth worrying about.

Also worth noting: large mathematical integers *should* be `sympy.Integer` types so this limit should only effect things like indices.