### PR TITLE
ipc: error on strings that are not row vectors

### DIFF
--- a/inst/private/python_copy_vars_to.m
+++ b/inst/private/python_copy_vars_to.m
@@ -53,6 +53,8 @@ function a = do_list(indent, in, varlist)
       c=c+1; a{c} = sprintf ('%s%s.append(%s)', sp, in, sprintf (sympy (x)));
 
     elseif (ischar(x))
+      assert (strcmp (x, '') || isrow (x), ...
+	      'multirow char arrays cannot be converted to Python strings')
       if (exist ('OCTAVE_VERSION', 'builtin'))
         x = undo_string_escapes(x);
       else

--- a/inst/python_cmd.m
+++ b/inst/python_cmd.m
@@ -466,16 +466,10 @@ end
 %! z = python_cmd ('return 3+2j');
 %! assert (z, 3+2i)
 
+%!error <multirow char arrays cannot>
+%! s = char ('abc', 'defgh', '12345');
+%! r = python_cmd ('return _ins[0]', s);
+
 %!test
-%! % multirow char arrays are a thing!
-%! % https://github.com/cbm755/octsympy/issues/664
-%! % expected behaviour: each row padded, only first row is kept
-%! if (exist ('OCTAVE_VERSION', 'builtin'))
-%! s = ['abc'; 'defgh'; '12345'];
-%! q = python_cmd ('return len(_ins)', s);
-%! assert (q == 1)
-%! q = python_cmd ('return len(_ins[0])', s);
-%! assert (q == 5)
-%! s2 = python_cmd ('return _ins[0]', s);
-%! assert (strcmp (s2, 'abc  '))
-%! end
+%! r = python_cmd ('return len(_ins[0])', '');
+%! assert (r == 0)


### PR DESCRIPTION
Previously we silently took the first row when a char array had multiple
rows.  See Issue #664.  Now we are more compatible with the `py` command.
See also: https://bitbucket.org/mtmiller/pytave/issues/75
Note `strcmp` against `''` rather than `isempty` to avoid `2 x 0` arrays.