### PR TITLE
Use sympy.compatibility to test for certain types

### DIFF
--- a/inst/private/check_and_convert.m
+++ b/inst/private/check_and_convert.m
@@ -30,8 +30,8 @@ function obj = check_and_convert(var_pyobj)
 
     sp = py.sympy;
     _sym = py.tuple({sp.Basic, sp.MatrixBase});
-    string_types = py.six.string_types;
-    integer_types = py.six.integer_types;
+    string_types = sp.compatibility.string_types;
+    integer_types = sp.compatibility.integer_types;
   end
 
 

--- a/inst/private/python_header.py
+++ b/inst/private/python_header.py
@@ -177,7 +177,7 @@ try:
             c = ET.SubElement(et, "list")
             for y in x:
                 octoutput(y, c)
-        elif isinstance(x, int) or (sys.version_info < (3, 0) and isinstance(x, long)):
+        elif isinstance(x, sp.compatibility.integer_types):
             a = ET.SubElement(et, "item")
             f = ET.SubElement(a, "f")
             f.text = str(OCTCODE_INT)
@@ -198,7 +198,7 @@ try:
             f.text = d2hex(x.real)
             f = ET.SubElement(a, "f")
             f.text = d2hex(x.imag)
-        elif isinstance(x, str) or (sys.version_info < (3, 0) and isinstance(x, unicode)):
+        elif isinstance(x, sp.compatibility.string_types):
             a = ET.SubElement(et, "item")
             f = ET.SubElement(a, "f")
             f.text = str(OCTCODE_STR)


### PR DESCRIPTION
Use the sympy.compatibility integer_types and string_types wrappers as
type checks.  No longer require the "six" module.

Fixes #775.