### PR TITLE
sympref: recover from setting an invalid ipc

### DIFF
--- a/inst/private/python_ipc_driver.m
+++ b/inst/private/python_ipc_driver.m
@@ -73,5 +73,10 @@ function [A, db] = python_ipc_driver(what, cmd, varargin)
       [A, db] = python_ipc_sysoneline(what, cmd, false, varargin{:});
 
     otherwise
-      error('invalid ipc mechanism')
+      if (strcmp(what, 'reset'))
+        A = true;
+        db = [];
+      else
+        error('invalid ipc mechanism')
+      end
   end

--- a/inst/sympref.m
+++ b/inst/sympref.m
@@ -420,6 +420,13 @@ end
 %! delete('tmp_python_cmd.py')
 
 %!test
+%! warning ('off', 'OctSymPy:sympref:invalidarg', 'local');
+%! sympref ('ipc', 'bogus');
+%! assert (strcmp (sympref ('ipc'), 'bogus'))
+
+%!error <invalid ipc mechanism> syms ('x')
+
+%!test
 %! sympref('defaults')
 %! assert(strcmp(sympref('ipc'), 'default'))
 %! sympref('quiet', 'on')


### PR DESCRIPTION
Allow sympref to restore everything to a working state with a valid ipc
after configuring an invalid ipc setting.

Fixes #783.