### PR TITLE
Use pytave on travis with OCT=daily builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,13 +5,17 @@ language: generic
 
 matrix:
   include:
-    - env: PYTHON=python2 PYTHON_VER=  PYTAVE=no SYMPY_VER=1.0 OCT=ppa   DOCTEST=yes COLUMNS=80
-    - env: PYTHON=python3 PYTHON_VER=3 PYTAVE=no SYMPY_VER=1.0 OCT=ppa   DOCTEST=yes COLUMNS=80
-    - env: PYTHON=python2 PYTHON_VER=  PYTAVE=no SYMPY_VER=1.0 OCT=daily DOCTEST=no COLUMNS=80
-    - env: PYTHON=python3 PYTHON_VER=3 PYTAVE=no SYMPY_VER=1.0 OCT=daily DOCTEST=no COLUMNS=80
+    - env: PYTHON=python2 PYTHON_VER=  PYTAVE=no  SYMPY_VER=1.0 OCT=ppa   DOCTEST=yes COLUMNS=80
+    - env: PYTHON=python3 PYTHON_VER=3 PYTAVE=no  SYMPY_VER=1.0 OCT=ppa   DOCTEST=yes COLUMNS=80
+    - env: PYTHON=python2 PYTHON_VER=  PYTAVE=no  SYMPY_VER=1.0 OCT=daily DOCTEST=no  COLUMNS=80
+    - env: PYTHON=python3 PYTHON_VER=3 PYTAVE=no  SYMPY_VER=1.0 OCT=daily DOCTEST=no  COLUMNS=80
+    - env: PYTHON=python2 PYTHON_VER=  PYTAVE=yes SYMPY_VER=1.0 OCT=daily DOCTEST=no  COLUMNS=80
+    - env: PYTHON=python3 PYTHON_VER=3 PYTAVE=yes SYMPY_VER=1.0 OCT=daily DOCTEST=no  COLUMNS=80
   allow_failures:
-    - env: PYTHON=python2 PYTHON_VER=  PYTAVE=no SYMPY_VER=1.0 OCT=daily DOCTEST=no COLUMNS=80
-    - env: PYTHON=python3 PYTHON_VER=3 PYTAVE=no SYMPY_VER=1.0 OCT=daily DOCTEST=no COLUMNS=80
+    - env: PYTHON=python2 PYTHON_VER=  PYTAVE=no  SYMPY_VER=1.0 OCT=daily DOCTEST=no  COLUMNS=80
+    - env: PYTHON=python3 PYTHON_VER=3 PYTAVE=no  SYMPY_VER=1.0 OCT=daily DOCTEST=no  COLUMNS=80
+    - env: PYTHON=python2 PYTHON_VER=  PYTAVE=yes SYMPY_VER=1.0 OCT=daily DOCTEST=no  COLUMNS=80
+    - env: PYTHON=python3 PYTHON_VER=3 PYTAVE=yes SYMPY_VER=1.0 OCT=daily DOCTEST=no  COLUMNS=80
 
 # need octave devel pkgs for doctest (has compiled code as of July 2015)
 before_install:
@@ -27,8 +31,9 @@ before_install:
         sudo tar --extract --directory=/usr/local --strip-components=1 --file=octave-ubuntu-trusty-snapshot.tar.xz;
     fi
   - sudo apt-get install -y python$PYTHON_VER-pip
+# we need python-dev and python3-dev but we can drop numpy after https://bitbucket.org/mtmiller/pytave/issues/84 is resolved.
   - if [ "x$PYTAVE" = "xyes" ]; then
-        sudo apt-get install -y libboost-python-dev python$PYTHON_VER-numpy;
+        sudo apt-get install -y python$PYTHON_VER-dev python$PYTHON_VER-numpy;
     fi
 
 install:
@@ -39,12 +44,11 @@ install:
         octave -W --no-gui --eval "pkg install doctest-0.5.0.tar.gz";
     fi
   - if [ "x$PYTAVE" = "xyes" ]; then
-        hg clone https://bitbucket.org/genuinelucifer/pytave_main pytave;
+        hg clone https://bitbucket.org/mtmiller/pytave pytave;
         pushd pytave;
-        hg checkout travis;
         pwd;
         autoreconf --install || exit 1;
-        ./configure && make || exit 1;
+        ./configure PYTHON_VERSION=$PYTHON_VER && make || exit 1;
         popd;
     fi
 
@@ -55,10 +59,15 @@ script:
   - stty cols $COLUMNS rows 40
   - tput cols; stty size
   - pushd inst
-  - octave --path=/home/travis/build/cbm755/octsympy/pytave -W --no-gui --eval "r = octsympy_tests; exit(r)"
+  - if [ "x$PYTAVE" = "xyes" ]; then
+        export IPC=native;
+    else
+        export IPC=default;
+    fi
+  - octave --path=$TRAVIS_BUILD_DIR/pytave -W --no-gui --eval "sympref ipc $IPC; r = octsympy_tests; exit(r)";
   - cat octsympy_tests.log
   - if [ "x$DOCTEST" = "xyes" ]; then
-        octave --path=/home/travis/build/cbm755/octsympy/pytave -W --no-gui --eval "pkg load doctest; syms x; r = doctest('.'); exit(~r)";
+        octave --path=$TRAVIS_BUILD_DIR/pytave -W --no-gui --eval "pkg load doctest; sympref ipc $IPC; syms x; r = doctest('.'); exit(~r)";
     fi
   - popd
 


### PR DESCRIPTION
Since, we are trying builds with latest octave, why not run those with pytave? As far as I remember pytave was always meant to be the default IPC, so I think we should use it when possible with new octave. It cannot be build with ppa but can be built with daily.  
Also, I found that `python3-dev` is present on travis but `python-dev` is not. So I added a line for installing `python$PYTHON_VERSION-dev`.  
Also, to properly build pytave with python3 there needs to be `PYTHON_VERSION=3`, I could have made a new variable but since we already had a `PYTHON_VER` so I renamed it.  
And, when path is being fed into octave, I used the variable $TRAVIS_BUILD_DIR so that I dont have to change the username in the path when I am running the build on travis connected to my account.