### PR TITLE
subs: multiple scalar variables can be replaced with symbolic matrices

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -1,6 +1,12 @@
 octsympy 2.6.1-dev
 ==================
 
+  * `subs` allows multiple scalar variables to be replaced with symbolic
+    matrix expressions.
+
+  * symfun can be evaluated at symbolic matrices: `f(sym([1 2; 3 4]))`
+    now works where `f(x)` is a symfun.
+
 
 
 octsympy 2.6.0 (2017-07-27)

--- a/inst/@sym/subs.m
+++ b/inst/@sym/subs.m
@@ -173,7 +173,7 @@ function g = subs(f, in, out)
     '(f, xx, yy) = _ins'
     'has_vec_sub = any(y.is_Matrix for y in yy)'
     'if not has_vec_sub:'
-    '    sublist = zip(xx, yy)'
+    '    sublist = list(zip(xx, yy))'
     '    g = f.subs(sublist, simultaneous=True).doit()'
     '    return g'
     '# more complicated when dealing with matrix/vector'
@@ -183,7 +183,7 @@ function g = subs(f, in, out)
     'g = zeros(*sizes.pop())'
     'for i in range(len(g)):'
     '    yyy = [y[i] if y.is_Matrix else y for y in yy]'
-    '    sublist = zip(xx, yyy)'
+    '    sublist = list(zip(xx, yyy))'
     '    g[i] = f.subs(sublist, simultaneous=True).doit()'
     'return g'
   };

--- a/inst/@symfun/subsref.m
+++ b/inst/@symfun/subsref.m
@@ -1,4 +1,4 @@
-%% Copyright (C) 2014, 2016 Colin B. Macdonald
+%% Copyright (C) 2014, 2016-2017 Colin B. Macdonald
 %%
 %% This file is part of OctSymPy.
 %%
@@ -43,7 +43,7 @@ function out = subsref (f, idx)
 
   switch idx.type
     case '()'
-      out = subs(f, f.vars, idx.subs);
+      out = subs (formula (f), argnames (f), idx.subs);
 
     case '.'
       fld = idx.subs;


### PR DESCRIPTION
Fixes #10 and #633 and upstream https://savannah.gnu.org/bugs/?func=detailitem&item_id=51091