### PR TITLE
release symbolic-sized matrices w/ int size

### DIFF
--- a/inst/@sym/private/make_sym_matrix.m
+++ b/inst/@sym/private/make_sym_matrix.m
@@ -25,12 +25,21 @@ function A = make_sym_matrix(As, sz)
   assert (~ isempty (regexp (As, '^\D\w*$')), 'Cannot create symbolic matrix with expression "%s"', As)
 
   if (isa(sz, 'sym'))
-    cmd = { 'As, sz = _ins'
-            'return sympy.MatrixSymbol(As, *sz),' };
-    A = python_cmd (cmd, As, sz);
+    cmd = { 'As, (n, m), = _ins'
+            'if n.is_Integer and m.is_Integer:'
+	    '    return (0, int(n), int(m)) '
+	    'else:'
+	    '    return (1, sympy.MatrixSymbol(As, n, m), 0)' };
+    [flag, n, m] = python_cmd (cmd, As, sz);
+    if (flag)
+      A = n;
+      return
+    end
   else
     n = int32(sz(1));
     m = int32(sz(2));
+  end
+
     % FIXME: returning an appropriate MatrixSymbol is nice idea,
     % but would need more work on IPC, size().  The ideal thing
     % might be a string representation that looks like this
@@ -51,6 +60,5 @@ function A = make_sym_matrix(As, sz)
             'A = sympy.Matrix(L)'
             'return A,' };
     A = python_cmd (cmd, As, n, m);
-  end
 
 end

--- a/inst/@sym/sym.m
+++ b/inst/@sym/sym.m
@@ -668,6 +668,12 @@ end
 %! assert (isa (A, 'sym'))
 
 %!test
+%! % symbolic matrix, symbolic but Integer size
+%! A = sym ('A', sym([2 3]));
+%! assert (isa (A, 'sym'))
+%! assert (isequal (size (A), [2 3]))
+
+%!test
 %! % symbolic matrix, subs in for size
 %! syms n m integer
 %! A = sym ('A', [n m]);


### PR DESCRIPTION
Previously, `sym('a', sym([1 2]))` was different than
`sym('a', [1 2])`; now both create the same thing.  Fixes #619.