### PR TITLE
reduce CI dependencies

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -26,7 +26,6 @@ before_install:
   - sudo apt-get install -y liboctave-dev
   - sudo apt-get install -y octave
   - if [ "x$OCT" = "xdaily" ]; then
-        sudo apt-get install -y libarpack2-dev libgl2ps-dev libgraphicsmagick++-dev libqrupdate-dev libsuitesparse-dev;
         wget https://s3.amazonaws.com/octave-snapshot/public/octave-ubuntu-trusty-snapshot.tar.xz;
         sudo tar --extract --directory=/usr/local --strip-components=1 --file=octave-ubuntu-trusty-snapshot.tar.xz;
     fi


### PR DESCRIPTION
See if we can build against the Octave daily snapshot now that upstream has been fixed to eliminate unnecessary dependencies on Ubuntu 14.04.