### PR TITLE
check for incompatible xml.dom in older Pythons

### DIFF
--- a/inst/private/assert_have_python_and_sympy.m
+++ b/inst/private/assert_have_python_and_sympy.m
@@ -199,10 +199,10 @@ function assert_have_python_and_sympy (pyexec, verbose)
     end
     disp ('**** Your Python is too old! ****')
     disp ('')
-    disp ('The XML output shown above must have "<item>value</item>" on the same line.')
-    disp ('If your Python interpreter is an old version of Python 2, or Python 3 older')
-    disp ('than 3.2.3, please try upgrading to a more recent Python to use the Symbolic')
-    disp ('package.')
+    disp ('The XML output shown above must have "<item>value</item>" all on one line.')
+    disp ('If your Python interpreter is an older release, please try upgrading to a more')
+    disp ('recent version.  Symbolic should work with Python 2 (version 2.7.3 or newer)')
+    disp ('and Python 3 (version 3.2.3 or newer).')
     return
   end
 

--- a/inst/private/assert_have_python_and_sympy.m
+++ b/inst/private/assert_have_python_and_sympy.m
@@ -159,9 +159,9 @@ function assert_have_python_and_sympy (pyexec, verbose)
     disp ('')
   end
 
-  script = 'import xml.dom.minidom as minidom;';
-  script = [script ' doc = minidom.parseString(\"<item>value</item>\");'];
-  script = [script ' print(doc.toprettyxml(indent=\"\"))'];
+  script = ['import xml.dom.minidom as minidom; ' ...
+            'doc = minidom.parseString(\"<item>value</item>\"); ' ...
+            'print(doc.toprettyxml(indent=\"\"))'];
 
   if (verbose)
     fprintf ('Attempting to run %s -c "%s"\n\n', pyexec, script);

--- a/inst/private/assert_have_python_and_sympy.m
+++ b/inst/private/assert_have_python_and_sympy.m
@@ -146,6 +146,7 @@ function assert_have_python_and_sympy (pyexec, verbose)
   end
 
   if (verbose)
+    disp ('')
     disp ('Good, a working version of SymPy is installed.')
     disp ('')
     disp ('')
@@ -153,8 +154,8 @@ function assert_have_python_and_sympy (pyexec, verbose)
     disp ('----------------------------------')
     disp ('')
     disp ('The XML DOM library is used by Symbolic for passing values to and from Python.')
-    disp ('Some older versions of Python formatted XML output differently.  If you have')
-    disp ('a Python that is older than 2.7.3 or 3.2.3, this will probably fail.')
+    disp ('Some older versions of Python formatted XML output differently.  As long as you')
+    disp ('have any reasonably recent version of Python, this should pass.')
     disp ('')
   end
 
@@ -175,8 +176,8 @@ function assert_have_python_and_sympy (pyexec, verbose)
   if (status ~= 0)
     if (~ verbose)
       error ('OctSymPy:noxmldom', ...
-            ['Python cannot import XML DOM: is there something unusual about your Python?\n' ...
-             '    Try "sympref diagnose" for more information.'])
+             ['Python cannot import XML DOM: is this an unusual Python setup?\n' ...
+              '    Try "sympref diagnose" for more information.'])
     end
     disp ('')
     disp ('Unfortunately status was non-zero: probably Python cannot import xml.dom.')
@@ -193,14 +194,14 @@ function assert_have_python_and_sympy (pyexec, verbose)
   if (isempty (strfind (xmlout, '<item>value</item>')))
     if (~ verbose)
       error ('OctSymPy:oldxmldom', ...
-             ['Python XML output is not compatible, probably an older version of Python?\n' ...
+             ['Python XML output is not compatible, probably an old version of Python?\n' ...
               '    Try "sympref diagnose" for more information.'])
     end
     disp ('**** Your Python is too old! ****')
     disp ('')
     disp ('The XML output shown above must have "<item>value</item>" on the same line.')
     disp ('If your Python interpreter is an old version of Python 2, or Python 3 older')
-    disp ('than 3.2.3, please try upgrading to a more recent version to use the Symbolic')
+    disp ('than 3.2.3, please try upgrading to a more recent Python to use the Symbolic')
     disp ('package.')
     return
   end

--- a/inst/private/assert_have_python_and_sympy.m
+++ b/inst/private/assert_have_python_and_sympy.m
@@ -146,6 +146,66 @@ function assert_have_python_and_sympy (pyexec, verbose)
   end
 
   if (verbose)
+    disp ('Good, a working version of SymPy is installed.')
+    disp ('')
+    disp ('')
+    disp ('Python XML Parsing and DOM Support')
+    disp ('----------------------------------')
+    disp ('')
+    disp ('The XML DOM library is used by Symbolic for passing values to and from Python.')
+    disp ('Some older versions of Python formatted XML output differently.  If you have')
+    disp ('a Python that is older than 2.7.3 or 3.2.3, this will probably fail.')
+    disp ('')
+  end
+
+  script = 'import xml.dom.minidom as minidom;';
+  script = [script ' doc = minidom.parseString(\"<item>value</item>\");'];
+  script = [script ' print(doc.toprettyxml(indent=\"\"))'];
+
+  if (verbose)
+    fprintf ('Attempting to run %s -c "%s"\n\n', pyexec, script);
+  end
+
+  [status, output] = system([pyexec ' -c "' script '"']);
+  if (verbose)
+    status
+    output
+  end
+
+  if (status ~= 0)
+    if (~ verbose)
+      error ('OctSymPy:noxmldom', ...
+            ['Python cannot import XML DOM: is there something unusual about your Python?\n' ...
+             '    Try "sympref diagnose" for more information.'])
+    end
+    disp ('')
+    disp ('Unfortunately status was non-zero: probably Python cannot import xml.dom.')
+    disp ('')
+    disp ('  * Is there an error message above?')
+    disp ('')
+    disp ('  * Are you using an unusual Python installation?  If not, please try to')
+    disp ('    reinstall it and try again.')
+    return
+  end
+
+  xmlout = strtrim (output);
+
+  if (isempty (strfind (xmlout, '<item>value</item>')))
+    if (~ verbose)
+      error ('OctSymPy:oldxmldom', ...
+             ['Python XML output is not compatible, probably an older version of Python?\n' ...
+              '    Try "sympref diagnose" for more information.'])
+    end
+    disp ('**** Your Python is too old! ****')
+    disp ('')
+    disp ('The XML output shown above must have "<item>value</item>" on the same line.')
+    disp ('If your Python interpreter is an old version of Python 2, or Python 3 older')
+    disp ('than 3.2.3, please try upgrading to a more recent version to use the Symbolic')
+    disp ('package.')
+    return
+  end
+
+  if (verbose)
     fprintf ('\nYour kit looks good for running the Symbolic package.  Happy hacking!\n\n')
   end
 end


### PR DESCRIPTION
This fixes #843 by adding another test case to the ipc init and to `sympref diagnose` for the xml.dom library.

I need to do some more testing on this with a few Python installations and maybe clean up some of the wording, but the basic approach is what I want to do. Testing and feedback on that welcome, especially anyone with Windows.