### PR TITLE
fortran: Fix typo in documentation.

### DIFF
--- a/inst/@sym/fortran.m
+++ b/inst/@sym/fortran.m
@@ -22,7 +22,7 @@
 %% @deftypemethodx @@sym {@var{s} =} fortran (@var{g1}, @dots{}, @var{gn})
 %% @deftypemethodx @@sym {} fortran (@dots{}, 'file', @var{filename})
 %% @deftypemethodx @@sym {[@var{F}, @var{H}] =} fortran (@dots{}, 'file', '')
-%% Convert symbolic expression into C code.
+%% Convert symbolic expression into Fortran code.
 %%
 %% Example returning a string of Fortran code:
 %% @example


### PR DESCRIPTION
Hello,

The documentation for the `fortran` function mentions that it generates C code,
which I believe is a typo.
