### PR TITLE
Fix componentwise operations/fcns on immutable matrices

### DIFF
--- a/inst/@sym/mrdivide.m
+++ b/inst/@sym/mrdivide.m
@@ -109,6 +109,12 @@ end
 %! B = sym(eye(2)) / A;
 %! assert (isequal (B, inv(A))  ||  strncmpi (sympy (B), 'MatPow', 6))
 
+%!xtest
+%! % immutable test, upstream: TODO
+%! A = sym([1 2; 3 4]);
+%! B = sym('ImmutableDenseMatrix([[Integer(1), Integer(2)], [Integer(3), Integer(4)]])');
+%! assert (isequal (A/A, B/B))
+
 %!test
 %! % A = C/B is C = A*B
 %! A = sym([1 2; 3 4]);

--- a/inst/@sym/power.m
+++ b/inst/@sym/power.m
@@ -1,4 +1,4 @@
-%% Copyright (C) 2014, 2016 Colin B. Macdonald
+%% Copyright (C) 2014, 2016, 2018 Colin B. Macdonald
 %%
 %% This file is part of OctSymPy.
 %%
@@ -73,6 +73,7 @@ function z = power(x, y)
 
   cmd = { '(x,y) = _ins'
           'if x.is_Matrix and y.is_Matrix:'
+          '    x = x.as_mutable()'
           '    for i in range(0, len(x)):'
           '        x[i] = x[i]**y[i]'
           '    return x,'
@@ -133,3 +134,9 @@ end
 %! % (1 on sympy 0.7.4--0.7.6, but nan in git (2014-12-12, a210908d4))
 %! zoo = sym('zoo');
 %! assert (isnan (1^zoo))
+
+%!test
+%! % immutable test
+%! A = sym([1 2]);
+%! B = sym('ImmutableDenseMatrix([[Integer(1), Integer(2)]])');
+%! assert (isequal (A.^A, B.^B))

--- a/inst/@sym/private/elementwise_op.m
+++ b/inst/@sym/private/elementwise_op.m
@@ -1,4 +1,4 @@
-%% Copyright (C) 2014, 2016 Colin B. Macdonald
+%% Copyright (C) 2014, 2016, 2018 Colin B. Macdonald
 %% Copyright (C) 2016 Lagu
 %%
 %% This file is part of OctSymPy.
@@ -86,7 +86,7 @@ function z = elementwise_op(scalar_fcn, varargin)
           'for A in _ins:'
           '    if isinstance(A, MatrixBase):'
           '        if q is None:'
-          '            q = A'
+          '            q = A.as_mutable()'
           '        else:'
           '            assert q.shape == A.shape, "Matrices in input must all have the same shape"'
           % in case all inputs were scalars:

--- a/inst/@sym/times.m
+++ b/inst/@sym/times.m
@@ -59,17 +59,17 @@ function z = times(x, y)
     return
   end
 
-  % 2016-03: cannot simply call hadamard_product, see upstream:
+  % 2018-01: TODO cannot simply call hadamard_product, see upstream:
   % https://github.com/sympy/sympy/issues/8557
 
   cmd = { '(x,y) = _ins'
           'if x is None or y is None:'
           '    return x*y'
           'if x.is_Matrix and y.is_Matrix:'
-          '    if isinstance(x, sp.MatrixExpr) or isinstance(y, sp.MatrixExpr):'
-          '        return hadamard_product(x, y)'
-          '    else:'
+          '    try:'
           '        return x.multiply_elementwise(y)'
+          '    except AttributeError:'
+          '        return hadamard_product(x, y)'
           'return x*y' };
 
   z = python_cmd (cmd, sym(x), sym(y));
@@ -94,3 +94,20 @@ end
 %! assert (isequal ( A.*A , D.*D  ))
 %! assert (isequal ( A.*D , D.*D  ))
 %! assert (isequal ( D.*A , D.*D  ))
+
+%!test
+%! % immutable test
+%! A = sym([1 2]);
+%! B = sym('ImmutableDenseMatrix([[Integer(1), Integer(2)]])');
+%! assert (isequal (A.*A, B.*B))
+
+%!test
+%! % MatrixSymbol test
+%! A = sym([1 2; 3 4]);
+%! B = sym('ImmutableDenseMatrix([[Integer(1), Integer(2)], [Integer(3), Integer(4)]])');
+%! C = sym('MatrixSymbol("C", 2, 2)');
+%! assert (strfind (sympy (C.*C), 'Hadamard'))
+%! assert (strfind (sympy (A.*C), 'Hadamard'))
+%! assert (strfind (sympy (C.*A), 'Hadamard'))
+%! assert (strfind (sympy (B.*C), 'Hadamard'))
+%! assert (strfind (sympy (C.*B), 'Hadamard'))

--- a/inst/@sym/times.m
+++ b/inst/@sym/times.m
@@ -68,7 +68,7 @@ function z = times(x, y)
           'if x.is_Matrix and y.is_Matrix:'
           '    try:'
           '        return x.multiply_elementwise(y)'
-          '    except AttributeError:'
+          '    except (AttributeError, TypeError):'
           '        return hadamard_product(x, y)'
           'return x*y' };
 

--- a/inst/@sym/triu.m
+++ b/inst/@sym/triu.m
@@ -1,4 +1,4 @@
-%% Copyright (C) 2014, 2016 Colin B. Macdonald
+%% Copyright (C) 2014, 2016, 2018 Colin B. Macdonald
 %%
 %% This file is part of OctSymPy.
 %%
@@ -55,9 +55,6 @@
 %% @seealso{@@sym/tril}
 %% @end defmethod
 
-%% Author: Colin B. Macdonald
-%% Keywords: symbolic
-
 function U = triu(A,k)
 
   if (nargin == 1)
@@ -71,6 +68,7 @@ function U = triu(A,k)
 
   cmd = { '(A,k) = _ins'
           'if A.is_Matrix:'
+          '    A = A.as_mutable()'
           '    (n,m) = A.shape'
           '    for c in range(0,m):'
           '        for r in range(max(0,1+c-k),n):'
@@ -114,3 +112,9 @@ end
 %! B = round(10*rand(3,4));
 %! assert (isequal (triu(B,sym(1)), triu(B,1)))
 %! assert (isa (triu(B,sym(1)), 'double'))
+
+%!test
+%! % immutable test
+%! A = sym('ImmutableDenseMatrix([[Integer(1), Integer(2)], [Integer(3), Integer(4)]])');
+%! assert (isequal (triu (A), sym ([1 2; 0 4])))
+%! assert (isequal (tril (A), sym ([1 0; 3 4])))

--- a/inst/vpa.m
+++ b/inst/vpa.m
@@ -349,3 +349,13 @@ end
 %! a = vpa('21e-1');
 %! b = vpa('2.1');
 %! assert (isequal (a, b))
+
+%!test
+%! % Issue #859, operations on immutable matrices
+%! x = vpa (sym ([1 2]));
+%! % If vpa no longer makes an ImmutableDenseMatrix,
+%! % may need to adjust or remove this test.
+%! assert (strfind (sympy (x), 'Immutable'))
+%! y = sin(x);
+%! y2 = [sin(vpa(sym(1))) sin(vpa(sym(2)))];
+%! assert (isequal (y, y2))


### PR DESCRIPTION
Then `elementwise_op` was added, it overwrites a reference to one
of the inputs.  This is not allowed for immutable matrices.  So
make a mutable copy instead.  Fixes #859.