### PR TITLE
[wip] Make popen2 ipc as quiet as possible

### DIFF
--- a/inst/private/python_have_quiet_flag.m
+++ b/inst/private/python_have_quiet_flag.m
@@ -1,0 +1,30 @@
+%% Copyright (C) 2018 Mike Miller
+%%
+%% This file is part of OctSymPy.
+%%
+%% OctSymPy is free software; you can redistribute it and/or modify
+%% it under the terms of the GNU General Public License as published
+%% by the Free Software Foundation; either version 3 of the License,
+%% or (at your option) any later version.
+%%
+%% This software is distributed in the hope that it will be useful,
+%% but WITHOUT ANY WARRANTY; without even the implied warranty
+%% of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See
+%% the GNU General Public License for more details.
+%%
+%% You should have received a copy of the GNU General Public
+%% License along with this software; see the file COPYING.
+%% If not, see <http://www.gnu.org/licenses/>.
+
+function r = python_have_quiet_flag (pyexec)
+%private function
+
+  if (ispc () && ~ isunix ())
+    [st, out] = system ([pyexec ' -q -c True 2> NUL']);
+  else
+    [st, out] = system ([pyexec ' -q -c True 2> /dev/null']);
+  end
+
+  r = (st == 0);
+
+end

--- a/inst/private/python_ipc_popen2.m
+++ b/inst/private/python_ipc_popen2.m
@@ -76,12 +76,15 @@ function [A, info] = python_ipc_popen2(what, cmd, varargin)
     end
     pyexec = sympref('python');
     assert_have_python_and_sympy (pyexec)
+    quiet_flag = ~verbose && python_have_quiet_flag (pyexec);
 
     if (ispc() && ~isunix() && compare_versions (OCTAVE_VERSION (), '4.0.2', '<='))
       if (verbose)
         disp('Using winwrapy.bat workaround for bug #43036 (Octave <= 4.0.2, on Windows)')
       end
       [fin, fout, pid] = popen2 ('winwrapy.bat', pyexec);
+    elseif (quiet_flag)
+      [fin, fout, pid] = popen2 (pyexec, '-iq');
     else
       [fin, fout, pid] = popen2 (pyexec, '-i');
     end


### PR DESCRIPTION
This is a proof of concept to attempt to run python without the normal interactive startup banner. When the `quiet` sympref is on, try to test whether the version of python being used accepts the `-q` option, and use it.

Re #863.