### PR TITLE
ci: update to doctest 0.6.1

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -44,8 +44,8 @@ install:
   - pip$PYTHON_VERSION install --user sympy==$SYMPY_VER
   - if [ "x$DOCTEST" = "xyes" ]; then
         mkdir ${HOME}/octave;
-        wget https://github.com/catch22/octave-doctest/releases/download/v0.5.0/doctest-0.5.0.tar.gz;
-        octave -W --no-gui --eval "pkg install doctest-0.5.0.tar.gz";
+        wget https://github.com/catch22/octave-doctest/releases/download/v0.6.1/doctest-0.6.1.tar.gz;
+        octave -W --no-gui --eval "pkg install doctest-0.6.1.tar.gz";
     fi
   - if [ "x$PYTAVE" = "xyes" ]; then
         hg clone https://bitbucket.org/mtmiller/pytave pytave;


### PR DESCRIPTION
Latest doctest release works for me locally, Travis always tests with Octave 4.2 or newer now, I see no reason not to update as long as tests pass.