### PR TITLE
Make it easier to customize the default python interpreter

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -25,6 +25,9 @@ octsympy 2.6.1-dev
 
   * Fixes for several bugs mentioning "immutable matrices".
 
+  * Added a `private/defaultpython.m` to make it easier for distributors
+    to control which python interpreter is used by default.
+
   * Various bug fixes and documentation updates.
 
 

--- a/inst/private/defaultpython.m
+++ b/inst/private/defaultpython.m
@@ -1,0 +1,37 @@
+%% Copyright (C) 2018 Mike Miller
+%% Copyright (C) 2018 Colin B. Macdonald
+%%
+%% This file is part of OctSymPy.
+%%
+%% OctSymPy is free software; you can redistribute it and/or modify
+%% it under the terms of the GNU General Public License as published
+%% by the Free Software Foundation; either version 3 of the License,
+%% or (at your option) any later version.
+%%
+%% This software is distributed in the hope that it will be useful,
+%% but WITHOUT ANY WARRANTY; without even the implied warranty
+%% of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See
+%% the GNU General Public License for more details.
+%%
+%% You should have received a copy of the GNU General Public
+%% License along with this software; see the file COPYING.
+%% If not, see <http://www.gnu.org/licenses/>.
+
+%% -*- texinfo -*-
+%% @defun defaultpython ()
+%% A string to execute to call a Python interpreter.
+%%
+%% Distributors/vendors may find this a convenient place to change
+%% the default python executable, e.g., to specify "python3" or to
+%% hardcode a path to a particular executable.
+%%
+%% End-users can always override this by setting the environment
+%% variable @code{PYTHON} as documented in @pxref{sympref}.
+%%
+%% @end defun
+
+function python = defaultpython ()
+
+  python = 'python';
+
+end

--- a/inst/sympref.m
+++ b/inst/sympref.m
@@ -1,4 +1,4 @@
-%% Copyright (C) 2014-2017 Colin B. Macdonald
+%% Copyright (C) 2014-2018 Colin B. Macdonald
 %% Copyright (C) 2017 NVS Abhilash
 %% Copyright (C) 2017 Mike Miller
 %%
@@ -58,7 +58,7 @@
 %% sympref reset
 %% @end example
 %% If the environment variable is empty or not set, the package
-%% uses a default setting (usually @code{python}).
+%% uses a default setting (often @code{python}).
 %%
 %%
 %% @strong{Display} of syms:
@@ -270,10 +270,9 @@ function varargout = sympref(cmd, arg)
       if (nargin ~= 1)
         error('old syntax ''sympref python'' removed; use ''setenv PYTHON'' instead')
       end
-      DEFAULTPYTHON = 'python';
       pyexec = getenv('PYTHON');
       if (isempty(pyexec))
-        pyexec = DEFAULTPYTHON;
+        pyexec = defaultpython ();
       end
       varargout{1} = pyexec;
 

--- a/util/make_windows_package.sh
+++ b/util/make_windows_package.sh
@@ -67,7 +67,7 @@ cp ${PYEXEREADME} ${WINDIR}/README.pyexe.txt
 
 # change default python to octpy.exe
 echo "making default python octpy.exe"
-sed -i "s/DEFAULTPYTHON = 'python'/DEFAULTPYTHON = 'octpy.exe'/" ${WINDIR}/inst/sympref.m
+sed -i "s/python = 'python'/python = 'octpy.exe'/" ${WINDIR}/inst/private/defaultpython.m
 
 # sympy and mpmath
 cp -pR ${SYMPY}/sympy ${WINDIR}/bin/ || exit 1


### PR DESCRIPTION
Provide a `private/defaultpython.m` that distributors/vendors can
tweak.  Fixes #879.