### PR TITLE
use 2.7.1+ for the dev version following 2.7.1

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,5 +1,5 @@
 Name: symbolic
-Version: 2.7.1
+Version: 2.7.1+
 Date: 2018-10-02
 Author: Colin B. Macdonald <cbm@m.fsf.org>
 Maintainer: Colin B. Macdonald <cbm@m.fsf.org>

--- a/NEWS
+++ b/NEWS
@@ -1,5 +1,5 @@
-octsympy 2.7.2-dev
-==================
+octsympy 2.7.1+
+===============
 
   * New symbolic commands:
 

--- a/inst/sympref.m
+++ b/inst/sympref.m
@@ -1,4 +1,4 @@
-%% Copyright (C) 2014-2018 Colin B. Macdonald
+%% Copyright (C) 2014-2019 Colin B. Macdonald
 %% Copyright (C) 2017 NVS Abhilash
 %% Copyright (C) 2017 Mike Miller
 %%
@@ -173,7 +173,7 @@
 %% @example
 %% @group
 %% sympref version
-%%   @result{} 2.7.2-dev
+%%   @result{} 2.7.1+
 %% @end group
 %% @end example
 %%
@@ -216,7 +216,7 @@ function varargout = sympref(cmd, arg)
 
     case 'version'
       assert (nargin == 1)
-      varargout{1} = '2.7.2-dev';
+      varargout{1} = '2.7.1+';
 
     case 'display'
       if (nargin == 1)


### PR DESCRIPTION
See upstream https://savannah.gnu.org/bugs/?55829, but basically
Octave's `compare_versions` thinks 2.7.2-dev comes after 2.7.2 but we
were using it as the version precediing 2.7.2.  "2.7.1+" should be
unambiguous.