### PR TITLE
monkey patch sympy for sinc disp and swap lambertw args

### DIFF
--- a/inst/@sym/lambertw.m
+++ b/inst/@sym/lambertw.m
@@ -1,4 +1,4 @@
-%% Copyright (C) 2015, 2016, 2018 Colin B. Macdonald
+%% Copyright (C) 2015, 2016, 2018-2019 Colin B. Macdonald
 %%
 %% This file is part of OctSymPy.
 %%
@@ -32,25 +32,21 @@
 %% lambertw(x)
 %%   @result{} (sym) LambertW(x)
 %% lambertw(2, x)
-%%   @result{} (sym) LambertW(x, 2)
+%%   @result{} (sym) LambertW(2, x)
 %% @end group
 %% @end example
-%% (@strong{Note} that the branch @var{k} must come first in the
-%% input but it comes last in the output.)
 %%
 %% Also supports vector/matrix input:
 %% @example
 %% @group
 %% syms x y
 %% lambertw([0 1], [x y])
-%%   @result{} (sym) [LambertW(x)  LambertW(y, 1)]  (1×2 matrix)
+%%   @result{} (sym) [LambertW(x)  LambertW(1, y)]  (1×2 matrix)
 %% @end group
 %% @end example
 %% @seealso{lambertw}
 %% @end defmethod
 
-%% Author: Colin B. Macdonald
-%% Keywords: symbolic
 
 function W = lambertw(k, x)
   if (nargin == 1)

--- a/inst/@sym/lambertw.m
+++ b/inst/@sym/lambertw.m
@@ -30,9 +30,9 @@
 %% @group
 %% syms x
 %% lambertw(x)
-%%   @result{} (sym) LambertW(x)
+%%   @result{} (sym) lambertw(x)
 %% lambertw(2, x)
-%%   @result{} (sym) LambertW(2, x)
+%%   @result{} (sym) lambertw(2, x)
 %% @end group
 %% @end example
 %%
@@ -41,7 +41,7 @@
 %% @group
 %% syms x y
 %% lambertw([0 1], [x y])
-%%   @result{} (sym) [LambertW(x)  LambertW(1, y)]  (1×2 matrix)
+%%   @result{} (sym) [lambertw(x)  lambertw(1, y)]  (1×2 matrix)
 %% @end group
 %% @end example
 %% @seealso{lambertw}

--- a/inst/@sym/lambertw.m
+++ b/inst/@sym/lambertw.m
@@ -1,4 +1,5 @@
 %% Copyright (C) 2015, 2016, 2018-2019 Colin B. Macdonald
+%% Copyright (C) 2019 Mike Miller
 %%
 %% This file is part of OctSymPy.
 %%

--- a/inst/@sym/sinc.m
+++ b/inst/@sym/sinc.m
@@ -25,7 +25,7 @@
 %% @example
 %% @group
 %% syms x
-%% rewrite(sinc(x), 'sin')
+%% rewrite (sinc (x), 'sin')
 %%   @result{} (sym)
 %%       ⎧sin(π⋅x)
 %%       ⎪────────  for π⋅x ≠ 0
@@ -35,42 +35,37 @@
 %% @end group
 %% @end example
 %%
-%% Unfortunately, the notation @code{sinc} is also commonly used to represent
+%% Caution, the notation @code{sinc} is also commonly used to represent
 %% the unnormalized sinc function
 %% @iftex
-%% @math{\frac{\sin(x)}{x}},
+%% @math{\frac{\sin(x)}{x}}.
 %% @end iftex
 %% @ifnottex
-%% @code{sin(x)/x},
+%% @code{sin(x)/x}.
 %% @end ifnottex
-%% and SymPy (the software underlying Symbolic) uses this definition.
-%% That means the output of symbolic expressions involving @code{sinc}
-%% would be confusing.  Instead, behind the scenes we rewrite it as
-%% @code{sincᵤₙ}:
-%% @example
-%% @c check python2: it prints "sinc_un"---fine but test will fail
-%% @c doctest: +XFAIL_UNLESS (python_cmd('return isinstance(u"", str)'))
-%% @group
-%% f = sinc(x)
-%%   @result{} f = (sym) sincᵤₙ(π⋅x)
-%% @end group
-%% @end example
-%% Here we typed our input in terms of the normalized sinc function
-%% whereas the output @code{sincᵤₙ(π⋅x)} is the equivalent SymPy expression
-%% written in terms of the unnormalized sinc function.
 %%
-%% Note conversion back into an Octave function works correctly as
-%% demonstrated next:
+%% Further examples:
 %% @example
 %% @group
-%% h = function_handle(f)
-%%   @result{} h = @@(x) sinc (x)
-%% double(sinc(sym(12)/10))
-%%   @result{} ans = -0.15591
-%% h(1.2)
-%%   @result{} ans = -0.15591
-%% sinc(1.2)
-%%   @result{} ans = -0.15591
+%% rewrite (sin (x)/x, 'sinc')
+%%   @result{} ans = (sym)
+%%            ⎛x⎞
+%%        sinc⎜─⎟
+%%            ⎝π⎠
+%% @end group
+%%
+%% @group
+%% rewrite (sin (pi*x)/(pi*x), 'sinc')
+%%   @result{} ans = (sym) sinc(x)
+%% @end group
+%%
+%% @group
+%% diff (sinc (x))
+%%   @result{} ans = (sym)
+%%        π⋅x⋅cos(π⋅x) - sin(π⋅x)
+%%        ───────────────────────
+%%                     2
+%%                  π⋅x
 %% @end group
 %% @end example
 %%
@@ -122,3 +117,12 @@ end
 %! A = sinc (1.5);
 %! B = h (1.5);
 %! assert (A, B, -eps)
+
+%!test
+%! syms x
+%! h = function_handle (sinc (x))
+%! A = double (sinc (sym (12)/10));
+%! B = h (1.2);
+%! C = sinc (1.2);
+%! assert (A, B, -eps)
+%! assert (A, C, -eps)

--- a/inst/@sym/sinc.m
+++ b/inst/@sym/sinc.m
@@ -45,15 +45,18 @@
 %% @end ifnottex
 %% and SymPy (the software underlying Symbolic) uses this definition.
 %% That means the output of symbolic expressions involving @code{sinc}
-%% can be confusing:
+%% would be confusing.  Instead, behind the scenes we rewrite it as
+%% @code{sincᵤₙ}:
 %% @example
+%% @c check python2: it prints "sinc_un"---fine but test will fail
+%% @c doctest: +XFAIL_UNLESS (python_cmd('return isinstance(u"", str)'))
 %% @group
 %% f = sinc(x)
-%%   @result{} f = (sym) sinc(π⋅x)
+%%   @result{} f = (sym) sincᵤₙ(π⋅x)
 %% @end group
 %% @end example
 %% Here we typed our input in terms of the normalized sinc function
-%% whereas the output @code{sinc(π⋅x)} is the equivalent SymPy expression
+%% whereas the output @code{sincᵤₙ(π⋅x)} is the equivalent SymPy expression
 %% written in terms of the unnormalized sinc function.
 %%
 %% Note conversion back into an Octave function works correctly as

--- a/inst/@sym/sinc.m
+++ b/inst/@sym/sinc.m
@@ -120,7 +120,7 @@ end
 
 %!test
 %! syms x
-%! h = function_handle (sinc (x))
+%! h = function_handle (sinc (x));
 %! A = double (sinc (sym (12)/10));
 %! B = h (1.2);
 %! C = sinc (1.2);

--- a/inst/private/python_header.py
+++ b/inst/private/python_header.py
@@ -1,4 +1,5 @@
 # Copyright (C) 2014-2017, 2019 Colin B. Macdonald
+# Copyright (C) 2019 Mike Miller
 # License: GPL-3.0-or-later, see python_header.m
 
 # In some cases this code is fed into stdin: two blank lines between

--- a/inst/private/python_header.py
+++ b/inst/private/python_header.py
@@ -55,7 +55,7 @@ try:
         g = f.func(*reversed(f.args), evaluate=False)
         return cls._print_Function(g, **kwargs)
     _mypp._print_LambertW = lambda cls, f: _my_rev_print(cls, f, func_name='lambertw')
-    _mypp._print_sinc = lambda cls, f: cls._print_Function(f, func_name="sinc_un")
+    _mypp._print_sinc = lambda cls, f: cls._print_Function(f.func(f.args[0]/sp.pi, evaluate=False))
     del _mypp
 except:
     echo_exception_stdout("in python_header import block")

--- a/inst/private/python_header.py
+++ b/inst/private/python_header.py
@@ -1,5 +1,5 @@
-# Copyright (C) 2014-2017 Colin B. Macdonald
-# Free Software without warranty, GPL-3.0+: see python_header.m
+# Copyright (C) 2014-2017, 2019 Colin B. Macdonald
+# License: GPL-3.0-or-later, see python_header.m
 
 # In some cases this code is fed into stdin: two blank lines between
 # try-except blocks, no blank lines within each block.
@@ -49,6 +49,14 @@ try:
     import itertools
     import collections
     from re import split
+    # patch pretty printer, issue #952
+    _mypp = pretty.__globals__["PrettyPrinter"]
+    def _my_rev_print(cls, f):
+        g = f.func(*reversed(f.args), evaluate=False)
+        return cls._print_Function(g)
+    _mypp._print_LambertW = _my_rev_print
+    _mypp._print_sinc = lambda cls, f: cls._print_Function(f, func_name="sinc_un")
+    del _mypp
 except:
     echo_exception_stdout("in python_header import block")
     raise

--- a/inst/private/python_header.py
+++ b/inst/private/python_header.py
@@ -51,10 +51,10 @@ try:
     from re import split
     # patch pretty printer, issue #952
     _mypp = pretty.__globals__["PrettyPrinter"]
-    def _my_rev_print(cls, f):
+    def _my_rev_print(cls, f, **kwargs):
         g = f.func(*reversed(f.args), evaluate=False)
-        return cls._print_Function(g)
-    _mypp._print_LambertW = _my_rev_print
+        return cls._print_Function(g, **kwargs)
+    _mypp._print_LambertW = lambda cls, f: _my_rev_print(cls, f, func_name='lambertw')
     _mypp._print_sinc = lambda cls, f: cls._print_Function(f, func_name="sinc_un")
     del _mypp
 except:


### PR DESCRIPTION
We patch the pretty printer to do this.  The `srepr` ("pickle") remains
unchanged so any actual mathematics are uneffected.

@mtmiller what do you think of this?

One downside is `sym('LambertW(5,6)')` will now be "wrong", at least for someone expecting it to match `lambertw(6,5)`.  But passing raw SymPy strings to `sym` isn't recommended anyway...

So this would fix things for normal users and potentially frustrate someone who knows a lot about SymPy (e.g., is consulting SymPy docs).

So should we:

1.  Do both (this PR).
2.  Do `sinc_un` but don't do `LambertW`.  The logic is `sinc` is worse b/c at least `lambertw` -> `LambertW` capitalization hints that something has happened...
3.  Do neither (e.g., acrument of technical debt for minimal benefit).
