### PR TITLE
gammainc: fix regularization

### DIFF
--- a/inst/@sym/gammainc.m
+++ b/inst/@sym/gammainc.m
@@ -21,16 +21,25 @@
 %% @defmethod  @@sym gammainc (@var{x}, @var{a})
 %% @defmethodx @@sym gammainc (@var{x}, @var{a}, 'lower')
 %% @defmethodx @@sym gammainc (@var{x}, @var{a}, 'upper')
-%% Symbolic incomplete gamma function.
+%% Symbolic regularized incomplete gamma function.
 %%
 %% Example:
 %% @example
 %% @group
 %% syms x a
 %% gammainc(x, a)
-%%   @result{} (sym) γ(a, x)
-%% gammainc(x,a, 'upper')
-%%   @result{} (sym) Γ(a, x)
+%%   @result{} (sym)
+%%       γ(a, x)
+%%       ───────
+%%         Γ(a)
+%% @end group
+%%
+%% @group
+%% gammainc(x, a, 'upper')
+%%   @result{} (sym)
+%%       Γ(a, x)
+%%       ───────
+%%         Γ(a)
 %% @end group
 %% @end example
 %%
@@ -42,7 +51,10 @@
 %% gammainc(3, 1)
 %%   @result{} ans = 0.95021
 %% gammainc(x, a)
-%%   @result{} (sym) γ(a, x)
+%%   @result{} (sym)
+%%       γ(a, x)
+%%       ───────
+%%         Γ(a)
 %% double(subs(ans, [x a], [3 1]))
 %%   @result{} ans = 0.95021
 %% @end group
@@ -67,6 +79,7 @@ function y = gammainc(z, a, which)
   else
     print_usage ();
   end
+  y = y ./ gamma (a);
 end
 
 
@@ -86,6 +99,13 @@ end
 %!test
 %! % compare to double
 %! x = 5; a = 1;
+%! A = gammainc (x, a);
+%! B = double (gammainc (sym(x), a));
+%! assert(A, B, -eps)
+
+%!test
+%! % compare to double where gamma(a) != 1
+%! x = 5; a = 3;
 %! A = gammainc (x, a);
 %! B = double (gammainc (sym(x), a));
 %! assert(A, B, -eps)
@@ -162,9 +182,29 @@ end
 %! syms x a
 %! f = gammainc (x, a, 'upper');
 %! h = function_handle (f, 'vars', [x a]);
+%! A = h (1.1, 2);
+%! B = gammainc (1.1, 2, 'upper');
+%! assert (A, B)
+
+%!test
+%! % round trip
+%! syms x a
+%! f = gammainc (x, a, 'lower');
+%! h = function_handle (f, 'vars', [x a]);
+%! A = h (1.1, 2);
+%! B = gammainc (1.1, 2, 'lower');
+%! assert (A, B)
+
+%!test
+%! % round trip
+%! syms x a
+%! f = gammainc (x, a, 'upper');
+%! h = function_handle (f, 'vars', [x a]);
 %! A = h (1.1, 2.2);
 %! B = gammainc (1.1, 2.2, 'upper');
+%! if (python_cmd ('return Version(spver) > Version("1.3")'))
 %! assert (A, B)
+%! end
 
 %!test
 %! % round trip
@@ -173,4 +213,6 @@ end
 %! h = function_handle (f, 'vars', [x a]);
 %! A = h (1.1, 2.2);
 %! B = gammainc (1.1, 2.2, 'lower');
+%! if (python_cmd ('return Version(spver) > Version("1.3")'))
 %! assert (A, B)
+%! end

--- a/inst/@sym/igamma.m
+++ b/inst/@sym/igamma.m
@@ -1,4 +1,4 @@
-%% Copyright (C) 2016 Colin B. Macdonald
+%% Copyright (C) 2016, 2019 Colin B. Macdonald
 %%
 %% This file is part of OctSymPy.
 %%
@@ -30,15 +30,17 @@
 %% @end group
 %% @end example
 %%
-%% @strong{Note} the order of inputs is different from
-%% @ref{@@sym/gammainc},
-%% specifically:
+%% @strong{Note} the order of inputs and scaling is different from
+%% @ref{@@sym/gammainc}, specifically:
 %% @example
 %% @group
 %% igamma (nu, x)
 %%   @result{} (sym) Γ(ν, x)
 %% gammainc (x, nu, 'upper')
-%%   @result{} (sym) Γ(ν, x)
+%%   @result{} (sym)
+%%       Γ(ν, x)
+%%       ───────
+%%         Γ(ν)
 %% @end group
 %% @end example
 %%
@@ -50,7 +52,7 @@ function y = igamma(a, z)
     print_usage ();
   end
 
-  y = gammainc(z, a, 'upper');
+  y = elementwise_op ('uppergamma', sym(a), sym(z));
 end
 
 
@@ -58,3 +60,22 @@ end
 %! % mostly tested in @sym/gammainc
 %! syms x
 %! assert (isequal (igamma (2, x), gammainc(x, 2, 'upper')))
+
+%!test
+%! % unregularized
+%! B = double (igamma (sym(3), 1));
+%! A = gammainc (1, 3, 'upper')*gamma (3);
+%! assert (A, B, -2*eps)
+
+%!test
+%! % something like a round trip: no igamma(<double>)
+%! syms x a
+%! f = igamma (a, x);
+%! h = function_handle (f, 'vars', [a x]);
+%! A = h (1.1, 2.2);
+%! B = double (igamma (sym(11)/10, sym(22)/10));
+%! C = gammainc (2.2, 1.1, 'upper')*gamma(1.1);
+%! if (python_cmd ('return Version(spver) > Version("1.3")'))
+%! assert (A, B, -10*eps)
+%! assert (A, C, -10*eps)
+%! end


### PR DESCRIPTION
gammainc is the regularized gamma function, so we need to divide by gamma
when implementing in terms of SymPy's uppergamma and lowergamma.  Add
tests.  Fixes #955.

The other function `sym.igamma` remains unregularized: it was correct
before this change.