### PR TITLE
comment out a test that is causing python crashes

### DIFF
--- a/inst/@sym/zeta.m
+++ b/inst/@sym/zeta.m
@@ -96,9 +96,10 @@ end
 %! B = h (2);
 %! assert (A, B, -eps)
 
-%!xtest
-%! % https://github.com/sympy/sympy/issues/11802
-%! assert (double (zeta (sym (3), 4)), -0.07264084989132137196, -1e-14)
+%%!xtest
+%%! % Disabled: causes stack overflows and crashes Python in Fedora 30
+%%! % https://github.com/sympy/sympy/issues/11802
+%%! assert (double (zeta (sym (3), 4)), -0.07264084989132137196, -1e-14)
 
 %!test
 %! syms x


### PR DESCRIPTION
Fixes Issue #977.  It was an xtest anyway, but now on Fedora 30, it
seems to be causing crashes.  Reported to upstream SymPy bug (same
URL noted in the comments of the test).