### PR TITLE
[maint] update to SPDX version 3.0 identifiers

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -13,4 +13,4 @@ Categories: symbolic
 Url: https://octave.sourceforge.io/symbolic
 Depends: octave (>= 4.2)
 SystemRequirements: python, sympy (>= 1.2)
-License: GPL-3.0+
+License: GPL-3.0-or-later

--- a/octave-symbolic.metainfo.xml
+++ b/octave-symbolic.metainfo.xml
@@ -37,7 +37,7 @@ without any warranty.
   <url type="bugtracker">https://github.com/cbm755/octsympy/issues/new</url>
   <translation/>
   <metadata_license>FSFAP</metadata_license>
-  <project_license>GPL-3.0+</project_license>
+  <project_license>GPL-3.0-or-later</project_license>
   <developer_name>Octave-Forge Community</developer_name>
   <update_contact>octave-maintainers@gnu.org</update_contact>
 </component>


### PR DESCRIPTION
SPDX version 3.0 defines the license tag `GPL-3.0-or-later`.