### PR TITLE
dsolve changes to make it more conforming to matlab return types

### DIFF
--- a/inst/@sym/dsolve.m
+++ b/inst/@sym/dsolve.m
@@ -39,8 +39,8 @@
 %% @group
 %% sol = dsolve (DE)
 %%   @result{} sol = (sym)
-%%     4⋅x
-%% C₁⋅ℯ
+%%           4⋅x
+%%       C₁⋅ℯ
 %% @end group
 %% @end example
 %%
@@ -49,8 +49,8 @@
 %% @group
 %% sol = dsolve (DE, y(0) == 1)
 %%   @result{} sol = (sym)
-%%  4⋅x
-%% ℯ
+%%        4⋅x
+%%       ℯ
 %% @end group
 %% @end example
 %% 
@@ -66,9 +66,9 @@
 %%
 %% [sol, classify] = dsolve (DE, y(0) == 1)
 %%   @result{} sol = (sym)
-%%  -1
-%% ─────
-%% x - 1
+%%        -1
+%%       ─────
+%%       x - 1
 %%   @result{} classify = separable
 %% @end group
 %% @end example
@@ -112,7 +112,7 @@
 %% 
 %%
 %% @group
-%% soln = dsolve (ode_sys)
+%% soln = dsolve (ode_sys);
 %% soln.x
 %%   @result{} ans =
 %%       (sym)

--- a/inst/@sym/dsolve.m
+++ b/inst/@sym/dsolve.m
@@ -193,7 +193,13 @@ function [soln,classify] = dsolve(ode,varargin)
           % If the solution set is iterable (system or multiple solutions),
           % we will convert it to a structure of {eqname: expr, eqname2: expr2 ...}
           % 'cause that's what matlab does!
-          'if iterable(sol):'
+          'try:'
+          '    iterator = iter(sol)'
+          'except TypeError:'
+          % Not iterable
+          '    pass'
+          'else:'
+          % Iterable
           '    return_data = dict()'
           '    for solution_part in sol:'
           '        results = convert(solution_part)'

--- a/inst/@sym/dsolve.m
+++ b/inst/@sym/dsolve.m
@@ -307,8 +307,8 @@ end
 %! soln = dsolve([ode1, ode2]);
 %! g1 = [2*C1*exp(-2*t) + 2*C2*exp(2*t), -2*C1*exp(-2*t) + 2*C2*exp(2*t)];
 %! g2 = [2*C1*exp(2*t) + 2*C2*exp(-2*t), 2*C1*exp(2*t) - 2*C2*exp(-2*t)];
-%! assert (isequal ([soln.x), soln.y], g1) || ...
-%!         isequal ([soln.x), soln.y], g2))
+%! assert (isequal ([soln.x, soln.y], g1) || ...
+%!         isequal ([soln.x, soln.y], g2))
 
 %!test
 %! % System of ODEs (initial-value problem)

--- a/inst/@sym/dsolve.m
+++ b/inst/@sym/dsolve.m
@@ -39,8 +39,8 @@
 %% @group
 %% sol = dsolve (DE)
 %%   @result{} sol = (sym)
-%%                  4⋅x
-%%       y(x) = C₁⋅ℯ
+%%     4⋅x
+%% C₁⋅ℯ
 %% @end group
 %% @end example
 %%
@@ -49,22 +49,11 @@
 %% @group
 %% sol = dsolve (DE, y(0) == 1)
 %%   @result{} sol = (sym)
-%%               4⋅x
-%%       y(x) = ℯ
+%%  4⋅x
+%% ℯ
 %% @end group
 %% @end example
-%%
-%% Note the result is an equation so if you need an expression
-%% for the solution:
-%% @example
-%% @group
-%% rhs (sol)
-%%   @result{} (sym)
-%%        4⋅x
-%%       ℯ
-%% @end group
-%% @end example
-%%
+%% 
 %% In some cases, SymPy can return a classification of the
 %% differential equation:
 %% @example
@@ -77,9 +66,9 @@
 %%
 %% [sol, classify] = dsolve (DE, y(0) == 1)
 %%   @result{} sol = (sym)
-%%                -1
-%%        y(x) = ─────
-%%               x - 1
+%%  -1
+%% ─────
+%% x - 1
 %%   @result{} classify = separable
 %% @end group
 %% @end example
@@ -97,10 +86,10 @@
 %%        dx
 %%
 %% dsolve (DE, y(0) == 1, diff(y)(0) == 12)
-%%   @result{} (sym) y(x) = 4⋅sin(3⋅x) + cos(3⋅x)
+%%   @result{} (sym) 4⋅sin(3⋅x) + cos(3⋅x)
 %%
 %% dsolve (DE, y(0) == 1, y(sym(pi)/2) == 2)
-%%   @result{} (sym) y(x) = -2⋅sin(3⋅x) + cos(3⋅x)
+%%   @result{} (sym) -2⋅sin(3⋅x) + cos(3⋅x)
 %% @end group
 %% @end example
 %%
@@ -120,26 +109,21 @@
 %%       ⎢──(y(t)) = 2⋅x(t)⎥
 %%       ⎣dt               ⎦
 %% @end group
+%% 
 %%
 %% @group
 %% soln = dsolve (ode_sys)
-%%   @result{} soln = @{ ... @}
-%% @end group
-%%
-%% @c doctest: +SKIP  # they might be re-ordered
-%% @group
-%% soln@{1@}
+%% soln.x
 %%   @result{} ans =
 %%       (sym)
-%%                      -2⋅t         2⋅t
-%%         x(t) = 2⋅C₁⋅ℯ     + 2⋅C₂⋅ℯ
+%%               2⋅t          -2⋅t
+%%         2⋅C₁⋅ℯ     + 2⋅C₂⋅ℯ
 %%
-%% @c doctest: +SKIP  # they might be re-ordered
-%% soln@{2@}
+%% soln.y
 %%   @result{} ans =
 %%       (sym)
-%%                        -2⋅t         2⋅t
-%%         y(t) = - 2⋅C₁⋅ℯ     + 2⋅C₂⋅ℯ
+%%               2⋅t          -2⋅t
+%%         2⋅C₁⋅ℯ     - 2⋅C₂⋅ℯ
 %% @end group
 %% @end example
 %%


### PR DESCRIPTION
Changes:
- `dsolve` returns the rhs of the resulting equation if it is a single equation with a function as lhs.
- Return values for implicit solutions unchanged. (Matches matlab)
- For a system of equations, returns a struct with fields labelled by the variable names, and values as the rhs of their corresponding equations. (Matches matlab)
- Updated test cases to remove calls to `rhs()` and index structs by the names of the variables.

Notable things that weren't changed:
- Return type is still [solution, classification], versus matlab's [solution1, solution2, ...]