### PR TITLE
On Windows, default to "python" not "python3"

### DIFF
--- a/inst/private/defaultpython.m
+++ b/inst/private/defaultpython.m
@@ -32,6 +32,12 @@
 
 function python = defaultpython ()
 
-  python = 'python3';
+  if (ispc () && (~isunix ()))
+    % 2020-03: Python.org installer/Anaconda do not provide python3
+    python = 'python';
+  else
+    % PEP394 says Python 3 installs should all provide this command
+    python = 'python3';
+  end
 
 end


### PR DESCRIPTION
It seems Anaconda and the official Python.org installer only provide
"python" and not "python3"