### PR TITLE
subsasgn: fix growing a scalar equality to matrix

### DIFF
--- a/inst/@sym/private/mat_rclist_asgn.m
+++ b/inst/@sym/private/mat_rclist_asgn.m
@@ -61,7 +61,7 @@ function z = mat_rclist_asgn(A, r, c, B)
           '    B = sp.Matrix([[B]])'
           'BT = B.T'
           '# copy of A, expanded and padded with zeros'
-          'if not A or not A.is_Matrix:'
+          'if A is None or not A.is_Matrix:'
           '    n = max( max(r)+1, 1 )'
           '    m = max( max(c)+1, 1 )'
           'else:'

--- a/inst/@sym/subsasgn.m
+++ b/inst/@sym/subsasgn.m
@@ -425,6 +425,13 @@ end
 %! e(1:2) = true;
 %! assert (isequal (e, [sym(1)==1  sym(2)==2  x==10  sym(3)==4]))
 
+%!test
+%! % grow scalar equality expression into a matrix of equalities
+%! syms a b c d
+%! e = a == b;
+%! e(2) = c == d;
+%! assert (isequal (e, [a==b  c==d]))
+
 
 %% 2D arrays from mat_mask_asgn
 


### PR DESCRIPTION
Fix test for LHS in indexed matrix assignment. Allow growing a scalar equality or inequality expression into a matrix. Fixes #1021.