### PR TITLE
Draft: Tweak some operations to work on later SymPy

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -57,16 +57,14 @@ jobs:
       fail-fast: false
       matrix:
         octave: [5.1.0, 5.2.0, 6.2.0, 6.4.0]
-        sympy: [1.4, 1.5.1, 1.6.2]
-        include:
-          - octave: 6.4.0
-            sympy: 1.7.1
-          - octave: 6.4.0
-            sympy: 1.8.0
-          - octave: 6.4.0
-            sympy: 1.9.0
-          - octave: 6.4.0
-            sympy: 1.10.1
+        sympy: [1.4, 1.5.1, 1.6.2, 1.7.1]
+        #include:
+        #  - octave: 6.4.0
+        #    sympy: 1.8.0
+        #  - octave: 6.4.0
+        #    sympy: 1.9.0
+        #  - octave: 6.4.0
+        #    sympy: 1.10.1
     steps:
       - uses: actions/checkout@v2
       - name:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -58,15 +58,15 @@ jobs:
       matrix:
         octave: [5.1.0, 5.2.0, 6.2.0, 6.4.0]
         sympy: [1.4, 1.5.1, 1.6.2]
-        #include:
-        #  - octave: 6.4.0
-        #    sympy: 1.7.1
-        #  - octave: 6.4.0
-        #    sympy: 1.8.0
-        #  - octave: 6.4.0
-        #    sympy: 1.9.0
-        #  - octave: 6.4.0
-        #    sympy: 1.10.1
+        include:
+          - octave: 6.4.0
+            sympy: 1.7.1
+          - octave: 6.4.0
+            sympy: 1.8.0
+          - octave: 6.4.0
+            sympy: 1.9.0
+          - octave: 6.4.0
+            sympy: 1.10.1
     steps:
       - uses: actions/checkout@v2
       - name:

--- a/inst/@sym/children.m
+++ b/inst/@sym/children.m
@@ -1,4 +1,4 @@
-%% Copyright (C) 2014, 2016, 2018-2019 Colin B. Macdonald
+%% Copyright (C) 2014, 2016, 2018-2019, 2022 Colin B. Macdonald
 %%
 %% This file is part of OctSymPy.
 %%
@@ -168,4 +168,12 @@ end
 %! % symbolic size matrix
 %! syms n m integer
 %! A = sym('a', [n m]);
-%! assert (isequal (children(A), [sym('a') n m]))
+%! C = children (A);
+%! assert (isequal (C(2), n))
+%! assert (isequal (C(3), m))
+
+%!xtest
+%! % symbolic size matrix, fails on newer SymPy Issue #1089
+%! syms n m integer
+%! A = sym('a', [n m]);
+%! assert (isequal (children (A), [sym('a') n m]))

--- a/inst/@sym/dsolve.m
+++ b/inst/@sym/dsolve.m
@@ -250,7 +250,7 @@ end
 %! de = diff(y, 2) + 4*y == 0;
 %! f = dsolve(de, y(0) == 2, y(1) == 0);
 %! g = -2*sin(2*x)/tan(sym('2'))+2*cos(2*x);
-%! assert (isequal (rhs(f), g))
+%! assert (isequal (simplify (rhs(f) - g), 0))
 
 %!test
 %! % Neumann boundary conditions (second order ode)
@@ -258,7 +258,7 @@ end
 %! de = diff(y, 2) + 4*y == 0;
 %! f = dsolve(de, subs(diff(y,x),x,0)==1, subs(diff(y,x),x,1)==0);
 %! g = sin(2*x)/2+cos(2*x)/(2*tan(sym('2')));
-%! assert (isequal (rhs(f), g))
+%! assert (isequal (simplify (rhs(f) - g), 0))
 
 %!test
 %! % Dirichlet-Neumann boundary conditions (second order ode)
@@ -266,7 +266,7 @@ end
 %! de = diff(y, 2) + 4*y == 0;
 %! f = dsolve(de, y(0) == 3, subs(diff(y,x),x,1)==0);
 %! g = 3*sin(2*x)*tan(sym('2'))+3*cos(2*x);
-%! assert (isequal (rhs(f), g))
+%! assert (isequal (simplify (rhs(f) - g), 0))
 
 %!test
 %! % System of ODEs

--- a/inst/@sym/isAlways.m
+++ b/inst/@sym/isAlways.m
@@ -117,7 +117,7 @@ function r = isAlways(p, varargin)
     '            if r in (S.true, S.false):'
     '                 return not bool(r)'
     '        if isinstance(p, (Lt, Gt, Le, Ge)):'
-    '            r = p._eval_relation(sp.simplify(p.lhs - p.rhs), 0)'
+    '            r = p._eval_relation(sp.simplify(p.lhs - p.rhs), sp.S(0))'
     '            r = simplify(r)'
     '            if r in (S.true, S.false):'
     '                 return not bool(r)'

--- a/inst/@sym/private/elementwise_op.m
+++ b/inst/@sym/private/elementwise_op.m
@@ -1,4 +1,4 @@
-%% Copyright (C) 2014, 2016, 2018-2019 Colin B. Macdonald
+%% Copyright (C) 2014, 2016, 2018-2019, 2022 Colin B. Macdonald
 %% Copyright (C) 2016 Lagu
 %%
 %% This file is part of OctSymPy.
@@ -89,9 +89,9 @@ function z = elementwise_op(scalar_fcn, varargin)
           '            q = A.as_mutable()'
           '        else:'
           '            assert q.shape == A.shape, "Matrices in input must all have the same shape"'
-          % in case all inputs were scalars:
+          % all inputs were scalars:
           'if q is None:'
-          '    q = Matrix([0])'
+          '    return _op(*_ins)'
           'for i in range(0, len(q)):'
           '    q[i] = _op(*[k[i] if isinstance(k, MatrixBase) else k for k in _ins])'
           'return q' ];

--- a/inst/@sym/private/elementwise_op.m
+++ b/inst/@sym/private/elementwise_op.m
@@ -92,9 +92,12 @@ function z = elementwise_op(scalar_fcn, varargin)
           % all inputs were scalars:
           'if q is None:'
           '    return _op(*_ins)'
+          % at least one input was a matrix:
+          '# dbout(f"at least one matrix param, shape={q.shape}")'
+          'elements = []'
           'for i in range(0, len(q)):'
-          '    q[i] = _op(*[k[i] if isinstance(k, MatrixBase) else k for k in _ins])'
-          'return q' ];
+          '    elements.append(_op(*[k[i] if isinstance(k, MatrixBase) else k for k in _ins]))'
+          'return Matrix(*q.shape, elements)' ];
 
   z = pycall_sympy__ (cmd, varargin{:});
 

--- a/inst/@sym/private/mat_rccross_access.m
+++ b/inst/@sym/private/mat_rccross_access.m
@@ -1,4 +1,4 @@
-%% Copyright (C) 2014, 2019 Colin B. Macdonald
+%% Copyright (C) 2014, 2019, 2022 Colin B. Macdonald
 %%
 %% This file is part of OctSymPy.
 %%
@@ -25,8 +25,11 @@
 %% Namely @code{':'}.
 %%
 %% @var{r} and @var{c} could contain duplicates.  This is one
-%% reason by this code doesn't easily replace
+%% reason why this code doesn't easily replace
 %% @code{mat_rclist_access}.
+%%
+%% @var{z} return is small matrix with @code{len(@var{c})} columns
+%% and @code{len(@var{r})} rows.
 %%
 %% @end defun
 
@@ -72,10 +75,11 @@ function z = mat_rccross_access(A, r, c)
   cmd = { '(A, rr, cc) = _ins'
           'if not A.is_Matrix:'
           '    A = sp.Matrix([A])'
-          'M = sp.Matrix.zeros(len(rr), len(cc))'
+          'M = [[0]*len(cc) for i in range(len(rr))]'
           'for i in range(0, len(rr)):'
           '    for j in range(0, len(cc)):'
-          '        M[i,j] = A[rr[i], cc[j]]'
+          '        M[i][j] = A[rr[i], cc[j]]'
+          'M = sp.Matrix(M)'
           'return M,' };
 
   rr = num2cell(int32(r-1));

--- a/inst/@sym/private/mat_rccross_access.m
+++ b/inst/@sym/private/mat_rccross_access.m
@@ -79,7 +79,9 @@ function z = mat_rccross_access(A, r, c)
           'for i in range(0, len(rr)):'
           '    for j in range(0, len(cc)):'
           '        M[i][j] = A[rr[i], cc[j]]'
-          'M = sp.Matrix(M)'
+          '# M = sp.Matrix(M)'
+          '# not quite b/c of preserving 3x0 and 0x3 for example'
+          'M = sp.Matrix(len(rr), len(cc), [c for r in M for c in r])'
           'return M,' };
 
   rr = num2cell(int32(r-1));

--- a/inst/@sym/private/mat_rclist_access.m
+++ b/inst/@sym/private/mat_rclist_access.m
@@ -1,4 +1,4 @@
-%% Copyright (C) 2014, 2016, 2019 Colin B. Macdonald
+%% Copyright (C) 2014, 2016, 2019, 2022 Colin B. Macdonald
 %%
 %% This file is part of OctSymPy.
 %%
@@ -36,9 +36,10 @@ function z = mat_rclist_access(A, r, c)
           'if A is None or not A.is_Matrix:'
           '    A = sp.Matrix([A])'
           'n = len(rr)'
-          'M = sp.Matrix.zeros(n, 1)'
-          'for i in range(0,n):'
-          '    M[i,0] = A[rr[i],cc[i]]'
+          'M = [[0]]*n'
+          'for i in range(0, n):'
+          '    M[i][0] = A[rr[i],cc[i]]'
+          'M = sp.Matrix(M)'
           'return M,' };
 
   rr = num2cell(int32(r-1));

--- a/inst/@sym/private/mat_rclist_access.m
+++ b/inst/@sym/private/mat_rclist_access.m
@@ -36,7 +36,7 @@ function z = mat_rclist_access(A, r, c)
           'if A is None or not A.is_Matrix:'
           '    A = sp.Matrix([A])'
           'n = len(rr)'
-          'M = [[0]]*n'
+          'M = [[0] for i in range(n)]'
           'for i in range(0, n):'
           '    M[i][0] = A[rr[i],cc[i]]'
           'M = sp.Matrix(M)'

--- a/inst/@sym/qr.m
+++ b/inst/@sym/qr.m
@@ -90,6 +90,8 @@ end
 %! [q, r] = qr(sym(6));
 %! assert (isequal (q, sym(1)))
 %! assert (isequal (r, sym(6)))
+
+%!test
 %! syms x
 %! [q, r] = qr(x);
 %! assert (isequal (q*r, x))

--- a/inst/findsymbols.m
+++ b/inst/findsymbols.m
@@ -1,4 +1,4 @@
-%% Copyright (C) 2014, 2016, 2018-2019 Colin B. Macdonald
+%% Copyright (C) 2014, 2016, 2018-2019, 2022 Colin B. Macdonald
 %%
 %% This file is part of OctSymPy.
 %%
@@ -59,7 +59,11 @@ function L = findsymbols(obj, dosort)
   end
 
   if isa(obj, 'sym')
-    cmd = { 's = _ins[0].free_symbols'
+    cmd = { 'if isinstance(_ins[0], MatrixBase):'
+            '    # having problems with Eq in matrices in SymPy >= 1.7.1'
+            '    s = set().union(*(i.free_symbols for i in _ins[0] if i is not None))'
+            'else:'
+            '    s = _ins[0].free_symbols'
             'l = list(s)'
             'l = sorted(l, key=str)'
             'return l,' };
@@ -174,3 +178,14 @@ end
 %! B = A^n;
 %! L = findsymbols(B);
 %! assert (isequal (L, {n x y}))
+
+%!test
+%! % array of eq
+%! syms x y
+%! assert (isequal (findsymbols (2 == [2 x y]), {x y}))
+
+%!test
+%! % array of ineq
+%! syms x y
+%! A = [x < 1  2*x < y  x >= 2  3 <= x  x != y];
+%! assert (isequal (findsymbols (A), {x y}))


### PR DESCRIPTION
Use a list-of-lists representation of a 2-d array internally instead of Matrix.  Convert to Matrix before returning.  This avoids SymPy 1.9 or 1.10 feature where element-by-element adding to a Matrix does some `if value:` which raises exceptions on `Eq` (equality) objects.

We're not supposed to be putting non-`Expr` objects in Matrices: this will help with that transition---but does not fix it.