### PR TITLE
Prefer packaging.version if its available

### DIFF
--- a/inst/private/python_header.py
+++ b/inst/private/python_header.py
@@ -53,9 +53,13 @@ try:
     import codecs
     import xml.etree.ElementTree as ET
     try:
-        from packaging.version import Version as LooseVersion
+        from packaging.version import Version
     except ImportError:
+        # will fail on Python 3.12
         from distutils.version import LooseVersion
+        def Version(v):
+            # short but not quite right: https://github.com/cbm755/octsympy/pull/320
+            return LooseVersion(v.replace('.dev', ''))
     import itertools
     import collections
     from re import split
@@ -93,9 +97,6 @@ try:
             if not k in b:
                 n[k] = a[k]
         return n
-    def Version(v):
-        # short but not quite right: https://github.com/cbm755/octsympy/pull/320
-        return LooseVersion(v.replace('.dev', ''))
     def myesc(s):
         # workaround https://bugs.python.org/issue25270
         if not s:

--- a/inst/private/python_ipc_native.m
+++ b/inst/private/python_ipc_native.m
@@ -80,9 +80,12 @@ function [A, info] = python_ipc_native(what, cmd, varargin)
                     'import struct'
                     'import codecs'
                     'try:'
-                    '    from packaging.version import Version as LooseVersion'
+                    '    from packaging.version import Version'
                     'except ImportError:'
                     '    from distutils.version import LooseVersion'
+                    '    def Version(v):'
+                    '        # short but not quite right: https://github.com/cbm755/octsympy/pull/320'
+                    '        return LooseVersion(v.replace(".dev", ""))'
                     'import itertools'
                     'import collections'
                     'from re import split'
@@ -102,9 +105,6 @@ function [A, info] = python_ipc_native(what, cmd, varargin)
                     '        if not k in b:'
                     '            n[k] = a[k]'
                     '    return n'
-                    'def Version(v):'
-                    '    # short but not quite right: https://github.com/cbm755/octsympy/pull/320'
-                    '    return LooseVersion(v.replace(".dev", ""))'
                   }, newl))
     have_headers = true;
   end


### PR DESCRIPTION
We knew back in https://github.com/cbm755/octsympy/pull/320 that
packaging was the nicer solution here so if we have packaging use its
Version directly.  The quick-n-dirty hacks are only when we fallback to
LooseVersion.

Related to Issue #1083.