### PR TITLE
doctest: update to Catalan printing for Sympy 1.10 issue #1093

### DIFF
--- a/inst/@sym/isconstant.m
+++ b/inst/@sym/isconstant.m
@@ -1,4 +1,5 @@
 %% Copyright (C) 2014-2016, 2019 Colin B. Macdonald
+%% Copyright (C) 2022 Chris Gorman
 %%
 %% This file is part of OctSymPy
 %%
@@ -24,12 +25,20 @@
 %% Example:
 %% @example
 %% @group
+%% @c doctest: +SKIP_UNLESS(pycall_sympy__ ('return Version(spver) < Version("1.10")'))
 %% syms x y
 %% A = [x 1 pi; 2 2*y catalan()]
 %%   @result{} A = (sym 2×3 matrix)
 %%       ⎡x   1      π   ⎤
 %%       ⎢               ⎥
 %%       ⎣2  2⋅y  Catalan⎦
+%% @c doctest: +SKIP_UNLESS(pycall_sympy__ ('return Version(spver) >= Version("1.10")'))
+%% syms x y
+%% A = [x 1 pi; 2 2*y catalan()]
+%%   @result{} A = (sym 2×3 matrix)
+%%      ⎡x   1   π⎤
+%%      ⎢         ⎥
+%%      ⎣2  2⋅y  G⎦
 %%
 %% isconstant (A)
 %%   @result{} ans =

--- a/inst/@sym/isconstant.m
+++ b/inst/@sym/isconstant.m
@@ -25,22 +25,16 @@
 %% Example:
 %% @example
 %% @group
-%% @c doctest: +SKIP_UNLESS(pycall_sympy__ ('return Version(spver) < Version("1.10")'))
 %% syms x y
-%% A = [x 1 pi; 2 2*y catalan()]
-%%   @result{} A = (sym 2×3 matrix)
-%%       ⎡x   1      π   ⎤
-%%       ⎢               ⎥
-%%       ⎣2  2⋅y  Catalan⎦
+%% A = [x 1 pi; 2 2*y catalan()] 
 %% @c doctest: +SKIP_UNLESS(pycall_sympy__ ('return Version(spver) >= Version("1.10")'))
-%% syms x y
-%% A = [x 1 pi; 2 2*y catalan()]
 %%   @result{} A = (sym 2×3 matrix)
 %%      ⎡x   1   π⎤
 %%      ⎢         ⎥
 %%      ⎣2  2⋅y  G⎦
 %%
 %% isconstant (A)
+%% @c doctest: +SKIP_UNLESS(pycall_sympy__ ('return Version(spver) >= Version("1.10")'))
 %%   @result{} ans =
 %%       0  1  1
 %%       1  0  1

--- a/inst/catalan.m
+++ b/inst/catalan.m
@@ -1,5 +1,6 @@
 %% Copyright (C) 2015 Carnë Draug
 %% Copyright (C) 2016, 2018-2019 Colin B. Macdonald
+%% Copyright (C) 2022 Chris Gorman
 %%
 %% This file is part of OctSymPy.
 %%
@@ -25,7 +26,7 @@
 %% @example
 %% @group
 %% catalan ()
-%%   @result{} (sym) Catalan
+%%   @result{} (sym) G
 %%
 %% vpa (catalan ())
 %%   @result{} (sym) 0.91596559417721901505460351493238

--- a/inst/catalan.m
+++ b/inst/catalan.m
@@ -25,6 +25,10 @@
 %%
 %% @example
 %% @group
+%% @c doctest: +SKIP_UNLESS(pycall_sympy__ ('return Version(spver) < Version("1.10")'))
+%% catalan ()
+%%   @result{} (sym) Catalan
+%% @c doctest: +SKIP_UNLESS(pycall_sympy__ ('return Version(spver) >= Version("1.10")'))
 %% catalan ()
 %%   @result{} (sym) G
 %%

--- a/inst/catalan.m
+++ b/inst/catalan.m
@@ -25,9 +25,6 @@
 %%
 %% @example
 %% @group
-%% @c doctest: +SKIP_UNLESS(pycall_sympy__ ('return Version(spver) < Version("1.10")'))
-%% catalan ()
-%%   @result{} (sym) Catalan
 %% @c doctest: +SKIP_UNLESS(pycall_sympy__ ('return Version(spver) >= Version("1.10")'))
 %% catalan ()
 %%   @result{} (sym) G


### PR DESCRIPTION
- Added copyright
- Fix expected return string from Sympy 1.10+ so doctest will pass
- note this change will make doctest fail for sympy < 1.10+