### PR TITLE
subs: fix false returning as 0 on newer SymPy

### DIFF
--- a/inst/@sym/subs.m
+++ b/inst/@sym/subs.m
@@ -1,4 +1,4 @@
-%% Copyright (C) 2014-2017, 2019 Colin B. Macdonald
+%% Copyright (C) 2014-2017, 2019, 2022 Colin B. Macdonald
 %%
 %% This file is part of OctSymPy.
 %%
@@ -256,12 +256,14 @@ function g = subs(f, in, out)
     'sizes = {(a.shape if a.is_Matrix else (1, 1)) for a in yy}'
     'sizes.discard((1, 1))'
     'assert len(sizes) == 1, "all substitions must be same size or scalar"'
-    'g = zeros(*sizes.pop())'
+    'size = sizes.pop()'
+    'numel = prod(size)'
+    'g = [0]*numel'
     'for i in range(len(g)):'
     '    yyy = [y[i] if y.is_Matrix else y for y in yy]'
     '    sublist = list(zip(xx, yyy))'
     '    g[i] = f.subs(sublist, simultaneous=True).doit()'
-    'return g'
+    'return Matrix(*size, g)'
   };
 
   g = pycall_sympy__ (cmd, f, in, out);

--- a/inst/@sym/subsasgn.m
+++ b/inst/@sym/subsasgn.m
@@ -1,4 +1,4 @@
-%% Copyright (C) 2014-2017, 2019 Colin B. Macdonald
+%% Copyright (C) 2014-2017, 2019, 2022 Colin B. Macdonald
 %% Copyright (C) 2016 Lagu
 %% Copyright (C) 2016 Abhinav Tripathi
 %%
@@ -629,6 +629,14 @@ end
 %! a = sym(7);
 %! a([]) = [42 42]
 
+%!test
+%! b = eye (3);
+%! a = sym (b);
+%! I = [2 3; 4 5];
+%! a(I) = -2*I;
+%! b(I) = -2*I;
+%! assert (isequal (a, sym (b)));
+%! assert (size (a), [3 3]);
 
 %% Tests from mat_replace
 


### PR DESCRIPTION
Fixes #1084 and Fixes #702.   I think these are unrelated fixes, just happen to be on same branch.