### PR TITLE
Allow for A = C / B when C is generated by A * B = C

### DIFF
--- a/inst/@sym/mrdivide.m
+++ b/inst/@sym/mrdivide.m
@@ -91,7 +91,7 @@ function z = mrdivide(x, y)
 end
 
 
-%!xtest
+%!test
 %! % scalar
 %! syms x
 %! assert (isa( x/x, 'sym'))


### PR DESCRIPTION
- remove doctest SKIP_IF sympy > 1.5.1
- replace xtests with test and remove reference to issue
- use solve command that oscarbenjamin suggested from upstream to fix
  issue.
- fixes issue #1079
- please use extra care with this fix as I am sick and may have made a
  mistake.