### PR TITLE
Changes octave pythonic interface 

### DIFF
--- a/inst/@sym/mrdivide.m
+++ b/inst/@sym/mrdivide.m
@@ -91,7 +91,7 @@ function z = mrdivide(x, y)
 end
 
 
-%!xtest
+%!test
 %! % scalar
 %! syms x
 %! assert (isa( x/x, 'sym'))

--- a/inst/private/check_and_convert.m
+++ b/inst/private/check_and_convert.m
@@ -46,7 +46,7 @@ function obj = check_and_convert(var_pyobj)
       obj{i} = get_sym_from_python(x);
     elseif (py.isinstance(x, list_or_tuple))
       obj{i} = check_and_convert(x);
-    elseif (py.isinstance (x, py.type(py.str())))
+    elseif (isa (x, 'py.str'))
       obj{i} = char (x);
     elseif (py.isinstance(x, builtins.dict))
       make_str_keys = pyeval ('lambda x: {str(k): v for k, v in x.items()}');
@@ -55,7 +55,7 @@ function obj = check_and_convert(var_pyobj)
       % make sure values are converted to sym
       s = structfun (@(t) check_and_convert (t){:}, s, 'UniformOutput', false);
       obj{i} = s;
-    elseif (py.isinstance(x, py.type(py.int())))
+    elseif (isa (x, 'py.int'))
       if (py.isinstance(x, pyeval('bool')))
         error ('unexpected python bool')
       end

--- a/inst/private/check_and_convert.m
+++ b/inst/private/check_and_convert.m
@@ -46,7 +46,7 @@ function obj = check_and_convert(var_pyobj)
       obj{i} = get_sym_from_python(x);
     elseif (py.isinstance(x, list_or_tuple))
       obj{i} = check_and_convert(x);
-    elseif (py.isinstance (x, py.str))
+    elseif (py.isinstance (x, py.type(py.str)))
       obj{i} = char (x);
     elseif (py.isinstance(x, builtins.dict))
       make_str_keys = pyeval ('lambda x: {str(k): v for k, v in x.items()}');

--- a/inst/private/check_and_convert.m
+++ b/inst/private/check_and_convert.m
@@ -46,7 +46,7 @@ function obj = check_and_convert(var_pyobj)
       obj{i} = get_sym_from_python(x);
     elseif (py.isinstance(x, list_or_tuple))
       obj{i} = check_and_convert(x);
-    elseif (py.isinstance (x, py.type(py.str)))
+    elseif (py.isinstance (x, py.type(py.str())))
       obj{i} = char (x);
     elseif (py.isinstance(x, builtins.dict))
       make_str_keys = pyeval ('lambda x: {str(k): v for k, v in x.items()}');
@@ -55,7 +55,7 @@ function obj = check_and_convert(var_pyobj)
       % make sure values are converted to sym
       s = structfun (@(t) check_and_convert (t){:}, s, 'UniformOutput', false);
       obj{i} = s;
-    elseif (py.isinstance(x, py.int))
+    elseif (py.isinstance(x, py.type(py.int())))
       if (py.isinstance(x, pyeval('bool')))
         error ('unexpected python bool')
       end


### PR DESCRIPTION
@cbm755 I believe I have made a git mess here.  Sorry.  If I'm spamming you with pull requests, please let me know.  My intention was to address issue 1115, on the pythonic interface failing to load properly, and I have run into issue 1079.

So I will recap, left to do for 1079 is to create an issue so we don't forget that changes may be needed for `mldivide.m` and `mrdivide.m`.  I will do this after issuing this PR.  At the very worst we will have two issues on the same topic.  If the code needs to be changed before merging into master please let me know.

For 1115, the edit is to `check_and_convert.m`, and a call to py.type(py.str) is needed to allow the creation of a symbolic variable.