### PR TITLE
various CI updates

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -166,10 +166,12 @@ jobs:
           pwd
           ls
           pip install sympy
-      - name: Install SymPy
+      - name: Install package, verify
         run: |
           make install
           octave --eval "pkg load symbolic; sympref diagnose"
+      - name: Load package, run tests
+        run: |
           # TODO: runs all the tests for some reason
           #octave --eval "pkg test symbolic"
           octave --eval "pkg load symbolic; r=octsympy_tests; if r, type('fntests.log') end; exit(r)"

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -147,3 +147,47 @@ jobs:
           docker stop oc
           docker rm oc
           ls
+
+
+  python3_10:
+    runs-on: ubuntu-22.04
+    steps:
+      - uses: actions/checkout@v2
+      - name: Run a multi-line script
+        run: |
+          sudo uname -a
+          python3 --version
+          sudo apt-get install -y octave
+          octave --version
+          python3 --version
+          #octave --eval "pkg install -forge doctest"
+          pwd
+          ls
+          pip install sympy
+          make -C octsympy install
+          octave --eval "pkg load symbolic; sympref diagnose"
+          # TODO: runs all the tests for some reason
+          #octave --eval "pkg test symbolic"
+          octave --eval "pkg load symbolic; r=octsympy_tests; if r, type('fntests.log') end; exit(r)"
+
+
+  python3_9:
+    runs-on: ubuntu-21.10
+    steps:
+      - uses: actions/checkout@v2
+      - name: Run a multi-line script
+        run: |
+          sudo uname -a
+          python3 --version
+          sudo apt-get install -y octave
+          octave --version
+          python3 --version
+          #octave --eval "pkg install -forge doctest"
+          pwd
+          ls
+          pip install sympy
+          make -C octsympy install
+          octave --eval "pkg load symbolic; sympref diagnose"
+          # TODO: runs all the tests for some reason
+          #octave --eval "pkg test symbolic"
+          octave --eval "pkg load symbolic; r=octsympy_tests; if r, type('fntests.log') end; exit(r)"

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -149,11 +149,11 @@ jobs:
           ls
 
 
-  python3_10:
+  ubuntu2204_python310:
     runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v2
-      - name: Run a multi-line script
+      - name: Install Octave
         run: |
           sudo uname -a
           python3 --version
@@ -161,32 +161,14 @@ jobs:
           octave --version
           python3 --version
           #octave --eval "pkg install -forge doctest"
-          pwd
-          ls
-          pip install sympy
-          make -C octsympy install
-          octave --eval "pkg load symbolic; sympref diagnose"
-          # TODO: runs all the tests for some reason
-          #octave --eval "pkg test symbolic"
-          octave --eval "pkg load symbolic; r=octsympy_tests; if r, type('fntests.log') end; exit(r)"
-
-
-  python3_9:
-    runs-on: ubuntu-21.10
-    steps:
-      - uses: actions/checkout@v2
-      - name: Run a multi-line script
+      - name: Install SymPy
         run: |
-          sudo uname -a
-          python3 --version
-          sudo apt-get install -y octave
-          octave --version
-          python3 --version
-          #octave --eval "pkg install -forge doctest"
           pwd
           ls
           pip install sympy
-          make -C octsympy install
+      - name: Install SymPy
+        run: |
+          make install
           octave --eval "pkg load symbolic; sympref diagnose"
           # TODO: runs all the tests for some reason
           #octave --eval "pkg test symbolic"

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -165,7 +165,7 @@ jobs:
         run: |
           pwd
           ls
-          pip install sympy
+          pip install sympy==1.8
       - name: Install package, verify
         run: |
           make install

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -101,16 +101,19 @@ jobs:
           ls
 
 
+  # note sympy 1.10 doesn't support Python 3.6 so won't work on 5.1.0/5.2.0
   doctests:
     runs-on: ubuntu-latest
     strategy:
       fail-fast: true
       matrix:
-        octave: [5.1.0, 6.4.0, 7.1.0]
+        octave: [6.4.0, 7.1.0]
         sympy: [1.4, 1.5.1, 1.6.2, 1.7.1, 1.8, 1.10.1]
         include:
+          - octave: 5.1.0
+            sympy: 1.4
           - octave: 5.2.0
-            sympy: 1.10.1
+            sympy: 1.8
     steps:
       - uses: actions/checkout@v2
       - name:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -107,10 +107,10 @@ jobs:
       fail-fast: true
       matrix:
         octave: [5.1.0, 6.4.0, 7.1.0]
-        sympy: [1.4, 1.5.1, 1.6.2, 1.7.1, 1.8]
+        sympy: [1.4, 1.5.1, 1.6.2, 1.7.1, 1.8, 1.10.1]
         include:
           - octave: 5.2.0
-            sympy: 1.8
+            sympy: 1.10.1
     steps:
       - uses: actions/checkout@v2
       - name:


### PR DESCRIPTION
Fixes #1069.  Fixes #1058.  Fixes #1103.

Keep SymPy back on 1.8 for Python 3.6 systems (the Ubuntu 18.04-based Octave 5.x.y containers)