### PR TITLE
Fixes for Octave 7.1.0

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -54,7 +54,7 @@ jobs:
     strategy:
       fail-fast: true
       matrix:
-        octave: [6.4.0]
+        octave: [7.1.0]
         sympy: [1.4, 1.5.1, 1.6.2, 1.7.1, 1.8, 1.10.1]
         include:
           - octave: 5.1.0
@@ -66,6 +66,8 @@ jobs:
           - octave: 6.2.0
             sympy: 1.10.1
           - octave: 6.3.0
+            sympy: 1.10.1
+          - octave: 6.4.0
             sympy: 1.10.1
     steps:
       - uses: actions/checkout@v2

--- a/inst/@double/bernoulli.m
+++ b/inst/@double/bernoulli.m
@@ -1,4 +1,4 @@
-%% Copyright (C) 2018-2019 Colin B. Macdonald
+%% Copyright (C) 2018-2019, 2022 Colin B. Macdonald
 %%
 %% This file is part of OctSymPy.
 %%
@@ -79,7 +79,7 @@ function y = bernoulli (m, x)
 end
 
 
-%!error <usage> bernoulli (1, 2, 3)
+%!error bernoulli (1, 2, 3)
 %!error <sizes> bernoulli ([1 2], [1 2 3])
 %!error <sizes> bernoulli ([1 2], [1; 2])
 

--- a/inst/@double/chebyshevT.m
+++ b/inst/@double/chebyshevT.m
@@ -1,4 +1,4 @@
-%% Copyright (C) 2018-2019 Colin B. Macdonald
+%% Copyright (C) 2018-2019, 2022 Colin B. Macdonald
 %%
 %% This file is part of OctSymPy.
 %%
@@ -76,10 +76,11 @@ function y = chebyshevT (n, x)
 end
 
 
+%!error chebyshevT (1)
+%!error chebyshevT (1, 2, 3)
+
 %!error <sizes> chebyshevT ([1 2], [1 2 3])
 %!error <sizes> chebyshevT ([1 2], [1; 2])
-%!error <Invalid> chebyshevT (1, 2, 3)
-%!error <Invalid> chebyshevT (1)
 
 %!test
 %! y = sym(11)/10;

--- a/inst/@double/chebyshevU.m
+++ b/inst/@double/chebyshevU.m
@@ -1,4 +1,4 @@
-%% Copyright (C) 2018-2019 Colin B. Macdonald
+%% Copyright (C) 2018-2019, 2022 Colin B. Macdonald
 %%
 %% This file is part of OctSymPy.
 %%
@@ -107,10 +107,11 @@ function y = chebyshevU (n, x)
 end
 
 
+%!error chebyshevU (1)
+%!error chebyshevU (1, 2, 3)
+
 %!error <sizes> chebyshevU ([1 2], [1 2 3])
 %!error <sizes> chebyshevU ([1 2], [1; 2])
-%!error <Invalid> chebyshevU (1, 2, 3)
-%!error <Invalid> chebyshevU (1)
 
 %!test
 %! y = sym(11)/10;

--- a/inst/@double/coshint.m
+++ b/inst/@double/coshint.m
@@ -1,4 +1,4 @@
-%% Copyright (C) 2016-2017, 2019 Colin B. Macdonald
+%% Copyright (C) 2016-2022 Colin B. Macdonald
 %%
 %% This file is part of OctSymPy.
 %%
@@ -53,6 +53,8 @@ function y = coshint (x)
   y = reshape (cell2mat (c), size (x));
 end
 
+
+%!error coshint (1, 2)
 
 %!test
 %! x = 1.1;

--- a/inst/@double/cosint.m
+++ b/inst/@double/cosint.m
@@ -1,4 +1,4 @@
-%% Copyright (C) 2016-2017, 2019 Colin B. Macdonald
+%% Copyright (C) 2016-2022 Colin B. Macdonald
 %%
 %% This file is part of OctSymPy.
 %%
@@ -53,6 +53,8 @@ function y = cosint (x)
   y = reshape (cell2mat (c), size (x));
 end
 
+
+%!error cosint (1, 2)
 
 %!test
 %! x = 1.1;

--- a/inst/@double/euler.m
+++ b/inst/@double/euler.m
@@ -1,4 +1,4 @@
-%% Copyright (C) 2017-2019 Colin B. Macdonald
+%% Copyright (C) 2017-2019, 2022 Colin B. Macdonald
 %%
 %% This file is part of OctSymPy.
 %%
@@ -85,7 +85,7 @@ function y = euler (m, x)
 end
 
 
-%!error <usage> euler (1, 2, 3)
+%!error euler (1, 2, 3)
 %!error <sizes> euler ([1 2], [1 2 3])
 %!error <sizes> euler ([1 2], [1; 2])
 

--- a/inst/@double/fresnelc.m
+++ b/inst/@double/fresnelc.m
@@ -1,4 +1,4 @@
-%% Copyright (C) 2016-2017, 2019 Colin B. Macdonald
+%% Copyright (C) 2016-2022 Colin B. Macdonald
 %%
 %% This file is part of OctSymPy.
 %%
@@ -53,6 +53,8 @@ function y = fresnelc (x)
   y = reshape (cell2mat (c), size (x));
 end
 
+
+%!error fresnelc (1, 2)
 
 %!test
 %! x = 1.1;

--- a/inst/@double/fresnels.m
+++ b/inst/@double/fresnels.m
@@ -1,4 +1,4 @@
-%% Copyright (C) 2016-2017, 2019 Colin B. Macdonald
+%% Copyright (C) 2016-2022 Colin B. Macdonald
 %%
 %% This file is part of OctSymPy.
 %%
@@ -53,6 +53,8 @@ function y = fresnels (x)
   y = reshape (cell2mat (c), size (x));
 end
 
+
+%!error fresnels (1, 2)
 
 %!test
 %! x = 1.1;

--- a/inst/@double/harmonic.m
+++ b/inst/@double/harmonic.m
@@ -1,4 +1,4 @@
-%% Copyright (C) 2017, 2019 Colin B. Macdonald
+%% Copyright (C) 2017-2022 Colin B. Macdonald
 %%
 %% This file is part of OctSymPy.
 %%
@@ -52,6 +52,8 @@ function y = harmonic (x)
   y = reshape (cell2mat (c), size (x));
 end
 
+
+%!error harmonic (1, 2)
 
 %!test
 %! x = 1.1;

--- a/inst/@double/logint.m
+++ b/inst/@double/logint.m
@@ -1,4 +1,4 @@
-%% Copyright (C) 2016-2017, 2019 Colin B. Macdonald
+%% Copyright (C) 2016-2022 Colin B. Macdonald
 %%
 %% This file is part of OctSymPy.
 %%
@@ -52,6 +52,8 @@ function y = logint (x)
   y = reshape (cell2mat (c), size (x));
 end
 
+
+%!error logint (1, 2)
 
 %!test
 %! x = 1.1;

--- a/inst/@double/pochhammer.m
+++ b/inst/@double/pochhammer.m
@@ -61,10 +61,11 @@ function y = pochhammer (n, x)
 end
 
 
+%!error pochhammer (1)
+%!error pochhammer (1, 2, 3)
+
 %!error <sizes> pochhammer ([1 2], [1 2 3])
 %!error <sizes> pochhammer ([1 2], [1; 2])
-%!error <Invalid> pochhammer (1, 2, 3)
-%!error <Invalid> pochhammer (1)
 
 %!test
 %! y = sym(11)/10;

--- a/inst/@double/polylog.m
+++ b/inst/@double/polylog.m
@@ -1,4 +1,4 @@
-%% Copyright (C) 2016, 2019 Colin B. Macdonald
+%% Copyright (C) 2016, 2019, 2022 Colin B. Macdonald
 %%
 %% This file is part of OctSymPy.
 %%
@@ -70,10 +70,11 @@ function y = polylog (s, x)
 end
 
 
+%!error polylog (1)
+%!error polylog (1, 2, 3)
+
 %!error <sizes> polylog ([1 2], [1 2 3])
 %!error <sizes> polylog ([1 2], [1; 2])
-%!error <Invalid> polylog (1, 2, 3)
-%!error <Invalid> polylog (1)
 
 %!test
 %! y = sym(11)/10;

--- a/inst/@double/sinhint.m
+++ b/inst/@double/sinhint.m
@@ -1,4 +1,4 @@
-%% Copyright (C) 2016-2017, 2019 Colin B. Macdonald
+%% Copyright (C) 2016-2022 Colin B. Macdonald
 %%
 %% This file is part of OctSymPy.
 %%
@@ -52,6 +52,8 @@ function y = sinhint (x)
   y = reshape (cell2mat (c), size (x));
 end
 
+
+%!error sinhint (1, 2)
 
 %!test
 %! x = 1.1;

--- a/inst/@double/sinint.m
+++ b/inst/@double/sinint.m
@@ -1,4 +1,4 @@
-%% Copyright (C) 2016-2017, 2019 Colin B. Macdonald
+%% Copyright (C) 2016-2022 Colin B. Macdonald
 %%
 %% This file is part of OctSymPy.
 %%
@@ -52,6 +52,8 @@ function y = sinint (x)
   y = reshape (cell2mat (c), size (x));
 end
 
+
+%!error sinint (1, 2)
 
 %!test
 %! x = 1.1;

--- a/inst/@double/zeta.m
+++ b/inst/@double/zeta.m
@@ -1,4 +1,4 @@
-%% Copyright (C) 2016-2019 Colin B. Macdonald
+%% Copyright (C) 2016-2019, 2022 Colin B. Macdonald
 %%
 %% This file is part of OctSymPy.
 %%
@@ -60,7 +60,7 @@ function y = zeta (n, x)
 end
 
 
-%!error <Invalid> zeta (1, 2, 3)
+%!error zeta (1, 2, 3)
 %!assert (isnan (zeta (nan)))
 
 %!test

--- a/inst/@logical/isAlways.m
+++ b/inst/@logical/isAlways.m
@@ -1,4 +1,4 @@
-%% Copyright (C) 2014, 2016 Colin B. Macdonald
+%% Copyright (C) 2014, 2016, 2022 Colin B. Macdonald
 %%
 %% This file is part of OctSymPy.
 %%
@@ -50,6 +50,6 @@ function r = isAlways(p)
 end
 
 
-%!error <Invalid> isAlways (true, false)
+%!error isAlways (true, false)
 %!assert(isAlways(true))
 %!assert(~isAlways(false))

--- a/inst/@sym/abs.m
+++ b/inst/@sym/abs.m
@@ -1,4 +1,4 @@
-%% Copyright (C) 2014-2016 Colin B. Macdonald
+%% Copyright (C) 2014-2022 Colin B. Macdonald
 %%
 %% This file is part of OctSymPy.
 %%
@@ -44,7 +44,7 @@ function y = abs(x)
 end
 
 
-%!error <Invalid> abs (sym(1), 2)
+%!error abs (sym(1), 2)
 %!assert (isequaln (abs (sym(nan)), sym(nan)))
 
 %!shared x, d

--- a/inst/@sym/acos.m
+++ b/inst/@sym/acos.m
@@ -1,4 +1,4 @@
-%% Copyright (C) 2014-2016 Colin B. Macdonald
+%% Copyright (C) 2014-2022 Colin B. Macdonald
 %%
 %% This file is part of OctSymPy.
 %%
@@ -44,7 +44,7 @@ function y = acos(x)
 end
 
 
-%!error <Invalid> acos (sym(1), 2)
+%!error acos (sym(1), 2)
 %!assert (isequaln (acos (sym(nan)), sym(nan)))
 
 %!shared x, d

--- a/inst/@sym/acosd.m
+++ b/inst/@sym/acosd.m
@@ -1,4 +1,4 @@
-%% Copyright (C) 2014-2016 Colin B. Macdonald
+%% Copyright (C) 2014-2016, 2022 Colin B. Macdonald
 %%
 %% This file is part of OctSymPy.
 %%
@@ -48,7 +48,7 @@ function y = acosd(x)
 end
 
 
-%!error <Invalid> acosd (sym(1), 2)
+%!error acosd (sym(1), 2)
 %!assert (isequaln (acosd (sym(nan)), sym(nan)))
 
 %!test

--- a/inst/@sym/acosh.m
+++ b/inst/@sym/acosh.m
@@ -1,4 +1,4 @@
-%% Copyright (C) 2014-2016 Colin B. Macdonald
+%% Copyright (C) 2014-2022 Colin B. Macdonald
 %%
 %% This file is part of OctSymPy.
 %%
@@ -44,7 +44,7 @@ function y = acosh(x)
 end
 
 
-%!error <Invalid> acosh (sym(1), 2)
+%!error acosh (sym(1), 2)
 %!assert (isequaln (acosh (sym(nan)), sym(nan)))
 
 %!shared x, d

--- a/inst/@sym/acot.m
+++ b/inst/@sym/acot.m
@@ -1,4 +1,4 @@
-%% Copyright (C) 2014-2016 Colin B. Macdonald
+%% Copyright (C) 2014-2022 Colin B. Macdonald
 %%
 %% This file is part of OctSymPy.
 %%
@@ -44,7 +44,7 @@ function y = acot(x)
 end
 
 
-%!error <Invalid> acot (sym(1), 2)
+%!error acot (sym(1), 2)
 %!assert (isequaln (acot (sym(nan)), sym(nan)))
 
 %!shared x, d

--- a/inst/@sym/acoth.m
+++ b/inst/@sym/acoth.m
@@ -1,4 +1,4 @@
-%% Copyright (C) 2014-2016 Colin B. Macdonald
+%% Copyright (C) 2014-2022 Colin B. Macdonald
 %%
 %% This file is part of OctSymPy.
 %%
@@ -44,7 +44,7 @@ function y = acoth(x)
 end
 
 
-%!error <Invalid> acoth (sym(1), 2)
+%!error acoth (sym(1), 2)
 %!assert (isequaln (acoth (sym(nan)), sym(nan)))
 
 %!shared x, d

--- a/inst/@sym/acsc.m
+++ b/inst/@sym/acsc.m
@@ -1,4 +1,4 @@
-%% Copyright (C) 2016 Colin B. Macdonald
+%% Copyright (C) 2016-2022 Colin B. Macdonald
 %%
 %% This file is part of OctSymPy.
 %%
@@ -44,7 +44,7 @@ function y = acsc(x)
 end
 
 
-%!error <Invalid> acsc (sym(1), 2)
+%!error acsc (sym(1), 2)
 %!assert (isequaln (acsc (sym(nan)), sym(nan)))
 
 %!shared x, d

--- a/inst/@sym/acsch.m
+++ b/inst/@sym/acsch.m
@@ -1,4 +1,4 @@
-%% Copyright (C) 2016 Colin B. Macdonald
+%% Copyright (C) 2016-2022 Colin B. Macdonald
 %%
 %% This file is part of OctSymPy.
 %%
@@ -44,7 +44,7 @@ function y = acsch(x)
 end
 
 
-%!error <Invalid> acsch (sym(1), 2)
+%!error acsch (sym(1), 2)
 %!assert (isequaln (acsch (sym(nan)), sym(nan)))
 
 %!shared x, d

--- a/inst/@sym/asec.m
+++ b/inst/@sym/asec.m
@@ -1,4 +1,4 @@
-%% Copyright (C) 2016 Colin B. Macdonald
+%% Copyright (C) 2016-2022 Colin B. Macdonald
 %%
 %% This file is part of OctSymPy.
 %%
@@ -44,7 +44,7 @@ function y = asec(x)
 end
 
 
-%!error <Invalid> asec (sym(1), 2)
+%!error asec (sym(1), 2)
 %!assert (isequaln (asec (sym(nan)), sym(nan)))
 
 %!shared x, d

--- a/inst/@sym/asech.m
+++ b/inst/@sym/asech.m
@@ -1,4 +1,4 @@
-%% Copyright (C) 2016 Colin B. Macdonald
+%% Copyright (C) 2016-2022 Colin B. Macdonald
 %%
 %% This file is part of OctSymPy.
 %%
@@ -44,7 +44,7 @@ function y = asech(x)
 end
 
 
-%!error <Invalid> asech (sym(1), 2)
+%!error asech (sym(1), 2)
 %!assert (isequaln (asech (sym(nan)), sym(nan)))
 
 %!shared x, d

--- a/inst/@sym/asin.m
+++ b/inst/@sym/asin.m
@@ -1,4 +1,4 @@
-%% Copyright (C) 2014-2016 Colin B. Macdonald
+%% Copyright (C) 2014-2022 Colin B. Macdonald
 %%
 %% This file is part of OctSymPy.
 %%
@@ -44,7 +44,7 @@ function y = asin(x)
 end
 
 
-%!error <Invalid> asin (sym(1), 2)
+%!error asin (sym(1), 2)
 %!assert (isequaln (asin (sym(nan)), sym(nan)))
 
 %!shared x, d

--- a/inst/@sym/asind.m
+++ b/inst/@sym/asind.m
@@ -1,4 +1,4 @@
-%% Copyright (C) 2014-2016 Colin B. Macdonald
+%% Copyright (C) 2014-2016, 2022 Colin B. Macdonald
 %%
 %% This file is part of OctSymPy.
 %%
@@ -48,7 +48,7 @@ function y = asind(x)
 end
 
 
-%!error <Invalid> asind (sym(1), 2)
+%!error asind (sym(1), 2)
 %!assert (isequaln (asind (sym(nan)), sym(nan)))
 
 %!test

--- a/inst/@sym/asinh.m
+++ b/inst/@sym/asinh.m
@@ -1,4 +1,4 @@
-%% Copyright (C) 2014-2016 Colin B. Macdonald
+%% Copyright (C) 2014-2022 Colin B. Macdonald
 %%
 %% This file is part of OctSymPy.
 %%
@@ -44,7 +44,7 @@ function y = asinh(x)
 end
 
 
-%!error <Invalid> asinh (sym(1), 2)
+%!error asinh (sym(1), 2)
 %!assert (isequaln (asinh (sym(nan)), sym(nan)))
 
 %!shared x, d

--- a/inst/@sym/atan.m
+++ b/inst/@sym/atan.m
@@ -1,4 +1,4 @@
-%% Copyright (C) 2014-2016 Colin B. Macdonald
+%% Copyright (C) 2014-2022 Colin B. Macdonald
 %%
 %% This file is part of OctSymPy.
 %%
@@ -44,7 +44,7 @@ function y = atan(x)
 end
 
 
-%!error <Invalid> atan (sym(1), 2)
+%!error atan (sym(1), 2)
 %!assert (isequaln (atan (sym(nan)), sym(nan)))
 
 %!shared x, d

--- a/inst/@sym/atan2.m
+++ b/inst/@sym/atan2.m
@@ -1,4 +1,4 @@
-%% Copyright (C) 2014, 2016, 2018 Colin B. Macdonald
+%% Copyright (C) 2014, 2016, 2018, 2022 Colin B. Macdonald
 %%
 %% This file is part of OctSymPy.
 %%
@@ -50,6 +50,9 @@ function a = atan2(y, x)
 
 end
 
+
+%!error atan2 (1)
+%!error atan2 (1, 2, 3)
 
 %!test
 %! % some angles

--- a/inst/@sym/atand.m
+++ b/inst/@sym/atand.m
@@ -1,4 +1,4 @@
-%% Copyright (C) 2014-2016 Colin B. Macdonald
+%% Copyright (C) 2014-2016, 2022 Colin B. Macdonald
 %%
 %% This file is part of OctSymPy.
 %%
@@ -48,7 +48,7 @@ function y = atand(x)
 end
 
 
-%!error <Invalid> atand (sym(1), 2)
+%!error atand (sym(1), 2)
 %!assert (isequaln (atand (sym(nan)), sym(nan)))
 
 %!test

--- a/inst/@sym/atanh.m
+++ b/inst/@sym/atanh.m
@@ -1,4 +1,4 @@
-%% Copyright (C) 2014-2016 Colin B. Macdonald
+%% Copyright (C) 2014-2022 Colin B. Macdonald
 %%
 %% This file is part of OctSymPy.
 %%
@@ -44,7 +44,7 @@ function y = atanh(x)
 end
 
 
-%!error <Invalid> atanh (sym(1), 2)
+%!error atanh (sym(1), 2)
 %!assert (isequaln (atanh (sym(nan)), sym(nan)))
 
 %!shared x, d

--- a/inst/@sym/bernoulli.m
+++ b/inst/@sym/bernoulli.m
@@ -61,7 +61,7 @@ function r = bernoulli (varargin)
 end
 
 
-%!error <usage> bernoulli (sym(1), 2, 3)
+%!error bernoulli (sym(1), 2, 3)
 
 %!assert (isequal (bernoulli (sym(8)), -sym(1)/30))
 %!assert (isequal (bernoulli (sym(9)), sym(0)))

--- a/inst/@sym/beta.m
+++ b/inst/@sym/beta.m
@@ -59,7 +59,7 @@ function r = beta(x, y)
 end
 
 
-%!error <usage> beta (sym(1), 2, 3)
+%!error beta (sym(1), 2, 3)
 
 %!assert (isequal (double (beta (sym(1), 2)), 1/2))
 %!assert (isinf (double (beta (sym(1), 0))))

--- a/inst/@sym/cbrt.m
+++ b/inst/@sym/cbrt.m
@@ -1,4 +1,4 @@
-%% Copyright (C) 2015-2018 Colin B. Macdonald
+%% Copyright (C) 2015-2022 Colin B. Macdonald
 %%
 %% This file is part of OctSymPy.
 %%
@@ -46,7 +46,7 @@ function y = cbrt(x)
 end
 
 
-%!error <Invalid> cbrt (sym(1), 2)
+%!error cbrt (sym(1), 2)
 %!assert (isequaln (cbrt (sym(nan)), sym(nan)))
 
 %!shared x, d

--- a/inst/@sym/ceil.m
+++ b/inst/@sym/ceil.m
@@ -1,4 +1,4 @@
-%% Copyright (C) 2014-2016 Colin B. Macdonald
+%% Copyright (C) 2014-2022 Colin B. Macdonald
 %%
 %% This file is part of OctSymPy.
 %%
@@ -44,7 +44,7 @@ function y = ceil(x)
 end
 
 
-%!error <Invalid> ceil (sym(1), 2)
+%!error ceil (sym(1), 2)
 %!assert (isequaln (ceil (sym(nan)), sym(nan)))
 
 %!shared x, d

--- a/inst/@sym/charpoly.m
+++ b/inst/@sym/charpoly.m
@@ -1,5 +1,5 @@
 %% Copyright (C) 2016 Lagu
-%% Copyright (C) 2017-2019 Colin B. Macdonald
+%% Copyright (C) 2017-2019, 2022 Colin B. Macdonald
 %%
 %% This file is part of OctSymPy.
 %%
@@ -98,7 +98,7 @@ function y = charpoly(varargin)
 end
 
 
-%!error <Invalid> charpoly (sym (1), 1, 2)
+%!error charpoly (sym (1), 1, 2)
 %!error <NonSquare> charpoly (sym ([1 2]))
 
 %!test

--- a/inst/@sym/chebyshevT.m
+++ b/inst/@sym/chebyshevT.m
@@ -64,8 +64,8 @@ function y = chebyshevT(n, x)
 end
 
 
-%!error <Invalid> chebyshevT (sym(1))
-%!error <Invalid> chebyshevT (sym(1), 2, 3)
+%!error chebyshevT (sym(1))
+%!error chebyshevT (sym(1), 2, 3)
 
 %!assert (isequaln (chebyshevT (2, sym(nan)), sym(nan)))
 

--- a/inst/@sym/chebyshevU.m
+++ b/inst/@sym/chebyshevU.m
@@ -64,8 +64,8 @@ function y = chebyshevU(n, x)
 end
 
 
-%!error <Invalid> chebyshevU (sym(1))
-%!error <Invalid> chebyshevU (sym(1), 2, 3)
+%!error chebyshevU (sym(1))
+%!error chebyshevU (sym(1), 2, 3)
 
 %!assert (isequaln (chebyshevU (2, sym(nan)), sym(nan)))
 

--- a/inst/@sym/coeffs.m
+++ b/inst/@sym/coeffs.m
@@ -1,4 +1,4 @@
-%% Copyright (C) 2014-2017, 2019 Colin B. Macdonald
+%% Copyright (C) 2014-2017, 2019, 2022 Colin B. Macdonald
 %%
 %% This file is part of OctSymPy.
 %%
@@ -168,7 +168,7 @@ function [c, t] = coeffs(p, x, all)
 end
 
 
-%!error <Invalid> coeffs (sym(1), 2, 3, 4)
+%!error coeffs (sym(1), 2, 3, 4)
 %!error <should be> coeffs (sym(1), 2, 'al')
 %!error <should be> coeffs (sym(1), 'al')
 

--- a/inst/@sym/cos.m
+++ b/inst/@sym/cos.m
@@ -1,4 +1,4 @@
-%% Copyright (C) 2014-2016 Colin B. Macdonald
+%% Copyright (C) 2014-2022 Colin B. Macdonald
 %%
 %% This file is part of OctSymPy.
 %%
@@ -44,7 +44,7 @@ function y = cos(x)
 end
 
 
-%!error <Invalid> cos (sym(1), 2)
+%!error cos (sym(1), 2)
 %!assert (isequaln (cos (sym(nan)), sym(nan)))
 
 %!shared x, d

--- a/inst/@sym/cosd.m
+++ b/inst/@sym/cosd.m
@@ -1,4 +1,4 @@
-%% Copyright (C) 2014-2016 Colin B. Macdonald
+%% Copyright (C) 2014-2016, 2022 Colin B. Macdonald
 %%
 %% This file is part of OctSymPy.
 %%
@@ -48,7 +48,7 @@ function y = cosd(x)
 end
 
 
-%!error <Invalid> cosd (sym(1), 2)
+%!error cosd (sym(1), 2)
 %!assert (isequaln (cosd (sym(nan)), sym(nan)))
 
 %!test

--- a/inst/@sym/cosd.m
+++ b/inst/@sym/cosd.m
@@ -61,4 +61,4 @@ end
 %! A = sym(D);
 %! f1 = cosd (A);
 %! f2 = cosd (D);
-%! assert (double (f1), f2, -eps)
+%! assert (double (f1), f2, -4*eps)

--- a/inst/@sym/cosh.m
+++ b/inst/@sym/cosh.m
@@ -1,4 +1,4 @@
-%% Copyright (C) 2014-2016 Colin B. Macdonald
+%% Copyright (C) 2014-2022 Colin B. Macdonald
 %%
 %% This file is part of OctSymPy.
 %%
@@ -44,7 +44,7 @@ function y = cosh(x)
 end
 
 
-%!error <Invalid> cosh (sym(1), 2)
+%!error cosh (sym(1), 2)
 %!assert (isequaln (cosh (sym(nan)), sym(nan)))
 
 %!shared x, d

--- a/inst/@sym/coshint.m
+++ b/inst/@sym/coshint.m
@@ -1,4 +1,4 @@
-%% Copyright (C) 2016 Colin B. Macdonald
+%% Copyright (C) 2016-2022 Colin B. Macdonald
 %%
 %% This file is part of OctSymPy.
 %%
@@ -44,7 +44,7 @@ function y = coshint(x)
 end
 
 
-%!error <Invalid> coshint (sym(1), 2)
+%!error coshint (sym(1), 2)
 %!xtest
 %! assert (isequaln (coshint (sym(nan)), sym(nan)))
 

--- a/inst/@sym/cosint.m
+++ b/inst/@sym/cosint.m
@@ -1,4 +1,4 @@
-%% Copyright (C) 2016 Colin B. Macdonald
+%% Copyright (C) 2016-2022 Colin B. Macdonald
 %%
 %% This file is part of OctSymPy.
 %%
@@ -44,7 +44,7 @@ function y = cosint(x)
 end
 
 
-%!error <Invalid> cosint (sym(1), 2)
+%!error cosint (sym(1), 2)
 %!xtest
 %! assert (isequaln (cosint (sym(nan)), sym(nan)))
 

--- a/inst/@sym/cot.m
+++ b/inst/@sym/cot.m
@@ -1,4 +1,4 @@
-%% Copyright (C) 2014-2016 Colin B. Macdonald
+%% Copyright (C) 2014-2022 Colin B. Macdonald
 %%
 %% This file is part of OctSymPy.
 %%
@@ -44,7 +44,7 @@ function y = cot(x)
 end
 
 
-%!error <Invalid> cot (sym(1), 2)
+%!error cot (sym(1), 2)
 %!assert (isequaln (cot (sym(nan)), sym(nan)))
 
 %!shared x, d

--- a/inst/@sym/coth.m
+++ b/inst/@sym/coth.m
@@ -1,4 +1,4 @@
-%% Copyright (C) 2014-2016 Colin B. Macdonald
+%% Copyright (C) 2014-2022 Colin B. Macdonald
 %%
 %% This file is part of OctSymPy.
 %%
@@ -44,7 +44,7 @@ function y = coth(x)
 end
 
 
-%!error <Invalid> coth (sym(1), 2)
+%!error coth (sym(1), 2)
 %!assert (isequaln (coth (sym(nan)), sym(nan)))
 
 %!shared x, d

--- a/inst/@sym/cross.m
+++ b/inst/@sym/cross.m
@@ -1,4 +1,4 @@
-%% Copyright (C) 2015, 2016, 2019 Colin B. Macdonald
+%% Copyright (C) 2015, 2016, 2019, 2022 Colin B. Macdonald
 %%
 %% This file is part of OctSymPy.
 %%
@@ -63,7 +63,7 @@ function c = cross(a, b)
 end
 
 
-%!error <Invalid> cross (sym(1), 2, 3)
+%!error cross (sym(1), 2, 3)
 
 %!test
 %! a = sym([1; 0; 0]);

--- a/inst/@sym/csc.m
+++ b/inst/@sym/csc.m
@@ -1,4 +1,4 @@
-%% Copyright (C) 2014-2016 Colin B. Macdonald
+%% Copyright (C) 2014-2022 Colin B. Macdonald
 %%
 %% This file is part of OctSymPy.
 %%
@@ -44,7 +44,7 @@ function y = csc(x)
 end
 
 
-%!error <Invalid> csc (sym(1), 2)
+%!error csc (sym(1), 2)
 %!assert (isequaln (csc (sym(nan)), sym(nan)))
 
 %!shared x, d

--- a/inst/@sym/csch.m
+++ b/inst/@sym/csch.m
@@ -1,4 +1,4 @@
-%% Copyright (C) 2016 Colin B. Macdonald
+%% Copyright (C) 2016-2022 Colin B. Macdonald
 %%
 %% This file is part of OctSymPy.
 %%
@@ -44,7 +44,7 @@ function y = csch(x)
 end
 
 
-%!error <Invalid> csch (sym(1), 2)
+%!error csch (sym(1), 2)
 %!assert (isequaln (csch (sym(nan)), sym(nan)))
 
 %!shared x, d

--- a/inst/@sym/cumprod.m
+++ b/inst/@sym/cumprod.m
@@ -136,13 +136,13 @@ endfunction
 %!shared x, y
 %! x = sym ('x');
 %! y = sym ('y');
+%!error cumprod (x, 1, 2)
 %!assert (isequal (cumprod ([-x; -2*x; -3*x]), [-x; 2*x^2; -6*x^3]))
 %!assert (isequal (expand (cumprod ([x + i, x - i])), [x + i, x^2 + 1]))
 %!assert (isequal (cumprod ([1, x; y, 2], 1), [1, x; y, 2*x] ))
 %!assert (isequal (cumprod ([1, x; y, 2], 2), [1, x; y, 2*y] ))
 %!test cumprod ([x, x], [2,  1]);   # ensure behaves like builtin cumprod
 %!test cumprod ([x, x], [1, -2]);   # ensure behaves like builtin cumprod
-%!error <Invalid call> cumprod (x, 1, 2)
 %!error <empty> cumprod (x, [])
 %!error <invalid dimension argument type> cumprod (x, {1})
 %!error <invalid dimension argument type> cumprod (x, struct('a', 1))

--- a/inst/@sym/cumsum.m
+++ b/inst/@sym/cumsum.m
@@ -130,13 +130,13 @@ endfunction
 %!shared x, y
 %! x = sym ('x');
 %! y = sym ('y');
+%!error cumsum (x, 1, 2)
 %!assert (isequal (cumsum ([-x; -2*x; -3*x]), [-x; -3*x; -6*x]))
 %!assert (isequal (cumsum ([x + 2i*y, 2*x + i*y]), [x + 2i*y, 3*x + 3i*y]))
 %!assert (isequal (cumsum ([x, 2*x; 3*x, 4*x], 1), [1*x, 2*x; 4*x, 6*x] ))
 %!assert (isequal (cumsum ([x, 2*x; 3*x, 4*x], 2), [1*x, 3*x; 3*x, 7*x] ))
 %!test cumsum ([x, x], [2,  1]);   # ensure behaves like builtin cumsum
 %!test cumsum ([x, x], [1, -2]);   # ensure behaves like builtin cumsum
-%!error <Invalid call> cumsum (x, 1, 2)
 %!error <empty> cumsum (x, [])
 %!error <invalid dimension argument type> cumsum (x, {1})
 %!error <invalid dimension argument type> cumsum (x, struct('a', 1))

--- a/inst/@sym/curl.m
+++ b/inst/@sym/curl.m
@@ -127,6 +127,8 @@ function g = curl(v,x)
 end
 
 
+%!error curl([sym(1) 2 3], 42, 42)
+
 %!shared x,y,z
 %! syms x y z
 
@@ -173,4 +175,3 @@ end
 
 %!error <3D vector> curl([sym(1) 2 3 4])
 %!error <three components> curl([sym(1) 2 3], {sym('x') sym('y') sym('z') sym('t')})
-%!error <Invalid> curl([sym(1) 2 3], 42, 42)

--- a/inst/@sym/degree.m
+++ b/inst/@sym/degree.m
@@ -1,4 +1,4 @@
-%% Copyright (C) 2015, 2016, 2019 Colin B. Macdonald
+%% Copyright (C) 2015, 2016, 2019, 2022 Colin B. Macdonald
 %%
 %% This file is part of OctSymPy.
 %%
@@ -70,7 +70,7 @@ function n = degree(p, x)
 end
 
 
-%!error <Invalid> degree (sym(1), 2, 3)
+%!error degree (sym(1), 2, 3)
 
 %!test
 %! syms x

--- a/inst/@sym/dirac.m
+++ b/inst/@sym/dirac.m
@@ -1,4 +1,4 @@
-%% Copyright (C) 2014-2016 Colin B. Macdonald
+%% Copyright (C) 2014-2022 Colin B. Macdonald
 %%
 %% This file is part of OctSymPy.
 %%
@@ -44,7 +44,7 @@ function y = dirac(x)
 end
 
 
-%!error <Invalid> dirac (sym(1), 2)
+%!error dirac (sym(1), 2)
 %!assert (isequaln (dirac (sym(nan)), sym(nan)))
 
 %!shared x, d

--- a/inst/@sym/dot.m
+++ b/inst/@sym/dot.m
@@ -1,4 +1,4 @@
-%% Copyright (C) 2015-2016, 2018-2019 Colin B. Macdonald
+%% Copyright (C) 2015-2016, 2018-2019, 2022 Colin B. Macdonald
 %% Copyright (C) 2016 Alex Vong
 %%
 %% This file is part of OctSymPy.
@@ -72,7 +72,7 @@ function c = dot(a, b)
 end
 
 
-%!error <Invalid> dot (sym(1), 2, 3)
+%!error dot (sym(1), 2, 3)
 
 %!test
 %! a = sym([1; 1; 0]);

--- a/inst/@sym/ellipke.m
+++ b/inst/@sym/ellipke.m
@@ -1,5 +1,5 @@
 %% Copyright (C) 2016-2017 Lagu
-%% Copyright (C) 2017 Colin B. Macdonald
+%% Copyright (C) 2017, 2022 Colin B. Macdonald
 %%
 %% This file is part of OctSymPy.
 %%
@@ -51,7 +51,7 @@ function varargout = ellipke(m)
 end
 
 
-%!error <Invalid> ellipke (sym(1), 2)
+%!error ellipke (sym(1), 2)
 
 %!test
 %! for i = 2:10

--- a/inst/@sym/ellipticCE.m
+++ b/inst/@sym/ellipticCE.m
@@ -1,5 +1,5 @@
 %% Copyright (C) 2016-2017 Lagu
-%% Copyright (C) 2017, 2019 Colin B. Macdonald
+%% Copyright (C) 2017, 2019, 2022 Colin B. Macdonald
 %%
 %% This file is part of OctSymPy.
 %%
@@ -60,7 +60,7 @@ function y = ellipticCE(m)
 end
 
 
-%!error <Invalid> ellipticCE (sym (1), 2)
+%!error ellipticCE (sym (1), 2)
 
 %!assert (isequal (ellipticCE (sym (0)), sym (1)))
 %!assert (isequal (ellipticCE (sym (1)), sym (pi)/2))

--- a/inst/@sym/ellipticCK.m
+++ b/inst/@sym/ellipticCK.m
@@ -1,5 +1,5 @@
 %% Copyright (C) 2016-2017 Lagu
-%% Copyright (C) 2017, 2019 Colin B. Macdonald
+%% Copyright (C) 2017, 2019, 2022 Colin B. Macdonald
 %%
 %% This file is part of OctSymPy.
 %%
@@ -60,7 +60,7 @@ function y = ellipticCK (m)
 end
 
 
-%!error <Invalid> ellipticCK (sym (1), 2)
+%!error ellipticCK (sym (1), 2)
 
 %!assert (double (ellipticCK (sym (1)/2)), 1.8541, 10e-5)
 %!assert (double (ellipticCK (sym (101)/10)), 0.812691836806976, -3*eps)

--- a/inst/@sym/ellipticCPi.m
+++ b/inst/@sym/ellipticCPi.m
@@ -1,5 +1,5 @@
 %% Copyright (C) 2016-2017 Lagu
-%% Copyright (C) 2017, 2019 Colin B. Macdonald
+%% Copyright (C) 2017, 2019, 2022 Colin B. Macdonald
 %%
 %% This file is part of OctSymPy.
 %%
@@ -64,8 +64,8 @@ function y = ellipticCPi(n, m)
 
 end
 
-%!error <Invalid> ellipticCPi (sym (1))
-%!error <Invalid> ellipticCPi (sym (1), 2, 3)
+%!error ellipticCPi (sym (1))
+%!error ellipticCPi (sym (1), 2, 3)
 
 %!assert (double (ellipticCPi (0, sym (1)/2)), 1.854074677, 10e-10)
 

--- a/inst/@sym/ellipticE.m
+++ b/inst/@sym/ellipticE.m
@@ -1,5 +1,5 @@
 %% Copyright (C) 2016-2017 Lagu
-%% Copyright (C) 2017 Colin B. Macdonald
+%% Copyright (C) 2017, 2022 Colin B. Macdonald
 %%
 %% This file is part of OctSymPy.
 %%
@@ -104,7 +104,7 @@ function y = ellipticE (phi, m)
 end
 
 
-%!error <Invalid> ellipticE (sym(1), 2, 3)
+%!error ellipticE (sym(1), 2, 3)
 
 %!assert (double (ellipticE (sym (-105)/10)), 3.70961391, 10e-9)
 %!assert (double (ellipticE (sym (-pi)/4)), 1.844349247, 10e-10)

--- a/inst/@sym/ellipticF.m
+++ b/inst/@sym/ellipticF.m
@@ -1,5 +1,5 @@
 %% Copyright (C) 2016-2017 Lagu
-%% Copyright (C) 2017 Colin B. Macdonald
+%% Copyright (C) 2017, 2022 Colin B. Macdonald
 %%
 %% This file is part of OctSymPy.
 %%
@@ -101,8 +101,8 @@ function y = ellipticF (phi, m)
 end
 
 
-%!error <Invalid> ellipticF (sym(1))
-%!error <Invalid> ellipticF (sym(1), 2, 3)
+%!error ellipticF (sym(1))
+%!error ellipticF (sym(1), 2, 3)
 
 %!assert (double (ellipticF (sym (pi)/3, sym (-105)/10)), 0.6184459461, 10e-11)
 %!assert (double (ellipticF (sym (pi)/4, sym (-pi))), 0.6485970495, 10e-11)

--- a/inst/@sym/ellipticK.m
+++ b/inst/@sym/ellipticK.m
@@ -1,5 +1,5 @@
 %% Copyright (C) 2016-2017 Lagu
-%% Copyright (C) 2017, 2019 Colin B. Macdonald
+%% Copyright (C) 2017, 2019, 2022 Colin B. Macdonald
 %%
 %% This file is part of OctSymPy.
 %%
@@ -83,7 +83,7 @@ function y = ellipticK (m)
 end
 
 
-%!error <Invalid> ellipticK (sym(1), 2)
+%!error ellipticK (sym(1), 2)
 
 %!assert (isequal (ellipticK (sym (0)), sym (pi)/2))
 %!assert (isequal (ellipticK (sym (-inf)), sym (0)))

--- a/inst/@sym/ellipticPi.m
+++ b/inst/@sym/ellipticPi.m
@@ -106,8 +106,8 @@ function y = ellipticPi (nu, phi, m)
 end
 
 
-%!error <Invalid> ellipticPi (sym (1))
-%!error <Invalid> ellipticPi (sym (1), 2, 3, 4)
+%!error ellipticPi (sym (1))
+%!error ellipticPi (sym (1), 2, 3, 4)
 
 %!assert (double (ellipticPi (sym (-23)/10, sym (pi)/4, 0)), 0.5876852228, 10e-11)
 %!assert (double (ellipticPi (sym (1)/3, sym (pi)/3, sym (1)/2)), 1.285032276, 10e-11)

--- a/inst/@sym/erf.m
+++ b/inst/@sym/erf.m
@@ -1,4 +1,4 @@
-%% Copyright (C) 2014-2016 Colin B. Macdonald
+%% Copyright (C) 2014-2022 Colin B. Macdonald
 %%
 %% This file is part of OctSymPy.
 %%
@@ -44,7 +44,7 @@ function y = erf(x)
 end
 
 
-%!error <Invalid> erf (sym(1), 2)
+%!error erf (sym(1), 2)
 %!assert (isequaln (erf (sym(nan)), sym(nan)))
 
 %!shared x, d

--- a/inst/@sym/erfc.m
+++ b/inst/@sym/erfc.m
@@ -1,4 +1,4 @@
-%% Copyright (C) 2014-2016 Colin B. Macdonald
+%% Copyright (C) 2014-2022 Colin B. Macdonald
 %%
 %% This file is part of OctSymPy.
 %%
@@ -44,7 +44,7 @@ function y = erfc(x)
 end
 
 
-%!error <Invalid> erfc (sym(1), 2)
+%!error erfc (sym(1), 2)
 %!assert (isequaln (erfc (sym(nan)), sym(nan)))
 
 %!shared x, d

--- a/inst/@sym/erfcinv.m
+++ b/inst/@sym/erfcinv.m
@@ -1,4 +1,4 @@
-%% Copyright (C) 2014-2016 Colin B. Macdonald
+%% Copyright (C) 2014-2022 Colin B. Macdonald
 %%
 %% This file is part of OctSymPy.
 %%
@@ -44,7 +44,7 @@ function y = erfcinv(x)
 end
 
 
-%!error <Invalid> erfcinv (sym(1), 2)
+%!error erfcinv (sym(1), 2)
 %!assert (isequaln (erfcinv (sym(nan)), sym(nan)))
 
 %!shared x, d

--- a/inst/@sym/erfi.m
+++ b/inst/@sym/erfi.m
@@ -1,4 +1,4 @@
-%% Copyright (C) 2014-2016, 2018 Colin B. Macdonald
+%% Copyright (C) 2014-2022 Colin B. Macdonald
 %%
 %% This file is part of OctSymPy.
 %%
@@ -44,7 +44,7 @@ function y = erfi(x)
 end
 
 
-%!error <Invalid> erfi (sym(1), 2)
+%!error erfi (sym(1), 2)
 %!assert (isequaln (erfi (sym(nan)), sym(nan)))
 
 %!shared x, d

--- a/inst/@sym/erfinv.m
+++ b/inst/@sym/erfinv.m
@@ -1,4 +1,4 @@
-%% Copyright (C) 2014-2016 Colin B. Macdonald
+%% Copyright (C) 2014-2022 Colin B. Macdonald
 %%
 %% This file is part of OctSymPy.
 %%
@@ -44,7 +44,7 @@ function y = erfinv(x)
 end
 
 
-%!error <Invalid> erfinv (sym(1), 2)
+%!error erfinv (sym(1), 2)
 %!assert (isequaln (erfinv (sym(nan)), sym(nan)))
 
 %!shared x, d

--- a/inst/@sym/euler.m
+++ b/inst/@sym/euler.m
@@ -1,4 +1,4 @@
-%% Copyright (C) 2017-2019 Colin B. Macdonald
+%% Copyright (C) 2017-2019, 2022 Colin B. Macdonald
 %%
 %% This file is part of OctSymPy.
 %%
@@ -68,7 +68,7 @@ function r = euler (varargin)
 end
 
 
-%!error <usage> euler (sym(1), 2, 3)
+%!error euler (sym(1), 2, 3)
 
 %!assert (isequal (euler (sym(0)), sym(1)))
 

--- a/inst/@sym/eval.m
+++ b/inst/@sym/eval.m
@@ -1,4 +1,4 @@
-%% Copyright (C) 2019 Colin B. Macdonald
+%% Copyright (C) 2019, 2022 Colin B. Macdonald
 %%
 %% This file is part of OctSymPy.
 %%
@@ -115,7 +115,7 @@ function g = eval(f)
 end
 
 
-%!error <Invalid> eval (sym(1), 2)
+%!error eval (sym(1), 2)
 
 %!assert (isnumeric (eval (sym(3))))
 %!assert (isnumeric (eval (sin (sym(3)))))

--- a/inst/@sym/exp.m
+++ b/inst/@sym/exp.m
@@ -1,4 +1,4 @@
-%% Copyright (C) 2014-2016 Colin B. Macdonald
+%% Copyright (C) 2014-2022 Colin B. Macdonald
 %%
 %% This file is part of OctSymPy.
 %%
@@ -46,7 +46,7 @@ function y = exp(x)
 end
 
 
-%!error <Invalid> exp (sym(1), 2)
+%!error exp (sym(1), 2)
 %!assert (isequaln (exp (sym(nan)), sym(nan)))
 
 %!shared x, d

--- a/inst/@sym/expint.m
+++ b/inst/@sym/expint.m
@@ -108,6 +108,8 @@ function y = expint(n, x)
 end
 
 
+%!error expint (sym(1), 2, 3)
+
 %!test
 %! f1 = expint(sym(1));
 %! f2 = expint(1);
@@ -136,8 +138,6 @@ end
 %! A = exp(-x)/x;
 %! B = expint(0, x);
 %! assert (isequal (A, B))
-
-%!error <Invalid call> expint(sym(1), 2, 3)
 
 %!test
 %! % round trip

--- a/inst/@sym/factorial.m
+++ b/inst/@sym/factorial.m
@@ -1,4 +1,4 @@
-%% Copyright (C) 2014-2016 Colin B. Macdonald
+%% Copyright (C) 2014-2022 Colin B. Macdonald
 %%
 %% This file is part of OctSymPy.
 %%
@@ -44,7 +44,7 @@ function y = factorial(x)
 end
 
 
-%!error <Invalid> factorial (sym(1), 2)
+%!error factorial (sym(1), 2)
 %!xtest
 %! assert (isequaln (factorial (sym(nan)), sym(nan)))
 

--- a/inst/@sym/find.m
+++ b/inst/@sym/find.m
@@ -1,4 +1,4 @@
-%% Copyright (C) 2019 Colin B. Macdonald
+%% Copyright (C) 2019, 2022 Colin B. Macdonald
 %%
 %% This file is part of OctSymPy.
 %%
@@ -144,8 +144,8 @@ function r = mylogical(p)
 end
 
 
-%!error <Invalid> find (sym (1), 2, 3, 4)
-%!error <Invalid> [x, y, z, w] = find (sym (1))
+%!error find (sym (1), 2, 3, 4)
+%!error <Invalid|too many outputs> [x, y, z, w] = find (sym (1))
 
 %!test
 %! syms x y positive

--- a/inst/@sym/floor.m
+++ b/inst/@sym/floor.m
@@ -1,4 +1,4 @@
-%% Copyright (C) 2014-2016 Colin B. Macdonald
+%% Copyright (C) 2014-2022 Colin B. Macdonald
 %%
 %% This file is part of OctSymPy.
 %%
@@ -44,7 +44,7 @@ function y = floor(x)
 end
 
 
-%!error <Invalid> floor (sym(1), 2)
+%!error floor (sym(1), 2)
 %!assert (isequaln (floor (sym(nan)), sym(nan)))
 
 %!shared x, d

--- a/inst/@sym/fresnelc.m
+++ b/inst/@sym/fresnelc.m
@@ -1,4 +1,4 @@
-%% Copyright (C) 2016, 2018-2019 Colin B. Macdonald
+%% Copyright (C) 2016, 2018-2019, 2022 Colin B. Macdonald
 %%
 %% This file is part of OctSymPy.
 %%
@@ -47,6 +47,8 @@ function J = fresnelc (x)
   J = elementwise_op ('fresnelc', x);
 end
 
+
+%!error fresnelc (sym(1), 2)
 
 %!test
 %! a = fresnelc(sym(0));

--- a/inst/@sym/fresnels.m
+++ b/inst/@sym/fresnels.m
@@ -1,4 +1,4 @@
-%% Copyright (C) 2016, 2018-2019 Colin B. Macdonald
+%% Copyright (C) 2016, 2018-2019, 2022 Colin B. Macdonald
 %%
 %% This file is part of OctSymPy.
 %%
@@ -47,6 +47,8 @@ function J = fresnels (x)
   J = elementwise_op ('fresnels', x);
 end
 
+
+%!error fresnels (sym(1), 2)
 
 %!test
 %! a = fresnels(sym(0));

--- a/inst/@sym/gamma.m
+++ b/inst/@sym/gamma.m
@@ -1,4 +1,4 @@
-%% Copyright (C) 2014-2016 Colin B. Macdonald
+%% Copyright (C) 2014-2022 Colin B. Macdonald
 %%
 %% This file is part of OctSymPy.
 %%
@@ -44,7 +44,7 @@ function y = gamma(x)
 end
 
 
-%!error <Invalid> gamma (sym(1), 2)
+%!error gamma (sym(1), 2)
 %!assert (isequaln (gamma (sym(nan)), sym(nan)))
 
 %!shared x, d

--- a/inst/@sym/harmonic.m
+++ b/inst/@sym/harmonic.m
@@ -110,7 +110,7 @@ function y = harmonic(x)
 end
 
 
-%!error <Invalid> harmonic (sym(1), 2)
+%!error harmonic (sym(1), 2)
 
 %!xtest
 %! assert (isequaln (harmonic (sym(nan)), sym(nan)))

--- a/inst/@sym/heaviside.m
+++ b/inst/@sym/heaviside.m
@@ -1,4 +1,4 @@
-%% Copyright (C) 2014-2016, 2018-2019 Colin B. Macdonald
+%% Copyright (C) 2014-2016, 2018-2019, 2022 Colin B. Macdonald
 %% Copyright (C) 2022 Chris Gorman
 %%
 %% This file is part of OctSymPy.
@@ -83,7 +83,7 @@ function y = heaviside(x, h0)
 end
 
 
-%!error <Invalid> heaviside (sym(1), 2, 3)
+%!error heaviside (sym(1), 2, 3)
 
 %!assert (isequal (heaviside (sym(1)), sym(1)))
 %!assert (isequal (heaviside (-sym(1)), sym(0)))

--- a/inst/@sym/hessian.m
+++ b/inst/@sym/hessian.m
@@ -1,4 +1,4 @@
-%% Copyright (C) 2014, 2016, 2019 Colin B. Macdonald
+%% Copyright (C) 2014, 2016, 2019, 2022 Colin B. Macdonald
 %%
 %% This file is part of OctSymPy.
 %%
@@ -99,6 +99,9 @@ function H = hessian(f, x)
 end
 
 
+%!error hessian (sym(1), 2, 3)
+%!error <only for scalar> hessian ([sym(1) sym(2)])
+
 %!shared x,y,z
 %! syms x y z
 
@@ -148,6 +151,3 @@ end
 %! Hexp = [0 0 -sin(z); sym(0) 0 0; -sin(z) 0 -f];
 %! H = hessian(f, {x y z});
 %! assert (isequal (H, Hexp))
-
-%!error <only for scalar> hessian([sym(1) sym(2)])
-%!error <Invalid call> hessian(sym(1), 2, 3)

--- a/inst/@sym/horner.m
+++ b/inst/@sym/horner.m
@@ -1,4 +1,4 @@
-%% Copyright (C) 2014-2016, 2019 Colin B. Macdonald
+%% Copyright (C) 2014-2016, 2019, 2022 Colin B. Macdonald
 %%
 %% This file is part of OctSymPy.
 %%
@@ -71,7 +71,7 @@ function y = horner(p, x)
 end
 
 
-%!error <Invalid> horner (sym(1), 2, 3)
+%!error horner (sym(1), 2, 3)
 
 %!assert (isAlways (horner(sym(1)) == 1))
 

--- a/inst/@sym/ifourier.m
+++ b/inst/@sym/ifourier.m
@@ -1,4 +1,4 @@
-%% Copyright (C) 2014-2016, 2018-2019 Colin B. Macdonald
+%% Copyright (C) 2014-2016, 2018-2019, 2022 Colin B. Macdonald
 %% Copyright (C) 2015-2016 Andrés Prieto
 %% Copyright (C) 2015 Alexander Misel
 %%
@@ -148,7 +148,7 @@ function f = ifourier(varargin)
 end
 
 
-%!error <Invalid> ifourier (sym(1), 2, 3, 4)
+%!error ifourier (sym(1), 2, 3, 4)
 
 %!test
 %! % matlab SMT compat

--- a/inst/@sym/ilaplace.m
+++ b/inst/@sym/ilaplace.m
@@ -144,7 +144,7 @@ function f = ilaplace(varargin)
 end
 
 
-%!error <Invalid> ilaplace (sym(1), 2, 3, 4)
+%!error ilaplace (sym(1), 2, 3, 4)
 
 %!test
 %! % basic SMT compact: no heaviside

--- a/inst/@sym/ipermute.m
+++ b/inst/@sym/ipermute.m
@@ -1,4 +1,4 @@
-%% Copyright (C) 2015, 2016, 2018 Colin B. Macdonald
+%% Copyright (C) 2015, 2016, 2018, 2022 Colin B. Macdonald
 %%
 %% This file is part of OctSymPy.
 %%
@@ -49,7 +49,8 @@ function A = ipermute(B, iperm)
 end
 
 
-%!error <Invalid> permute (sym(1))
+%!error permute (sym(1))
+%!error permute (sym(1), 2, 3)
 
 %!test
 %! syms x

--- a/inst/@sym/jacobian.m
+++ b/inst/@sym/jacobian.m
@@ -1,4 +1,4 @@
-%% Copyright (C) 2014, 2016, 2019 Colin B. Macdonald
+%% Copyright (C) 2014, 2016, 2019, 2022 Colin B. Macdonald
 %%
 %% This file is part of OctSymPy.
 %%
@@ -110,6 +110,9 @@ function g = jacobian(f, x)
 end
 
 
+%!error jacobian (sym(1), 2, 3)
+%!error <only for vectors> jacobian ([sym(1) 2; sym(3) 4])
+
 %!shared x,y,z
 %! syms x y z
 
@@ -169,6 +172,3 @@ end
 %! assert (isequal (size(jacobian(f, x)), [2 1]))
 %! f = f.';  % same shape output
 %! assert (isequal (size(jacobian(f, x)), [2 1]))
-
-%!error <only for vectors> jacobian([sym(1) 2; sym(3) 4])
-%!error <Invalid call> jacobian(sym(1), 2, 3)

--- a/inst/@sym/kroneckerDelta.m
+++ b/inst/@sym/kroneckerDelta.m
@@ -71,7 +71,7 @@ function a = kroneckerDelta (n, m)
 end
 
 
-%!error <Invalid> kroneckerDelta (sym(1), 2, 3)
+%!error kroneckerDelta (sym(1), 2, 3)
 
 %!test
 %! syms x

--- a/inst/@sym/limit.m
+++ b/inst/@sym/limit.m
@@ -1,4 +1,4 @@
-%% Copyright (C) 2014-2016 Colin B. Macdonald
+%% Copyright (C) 2014-2016, 2022 Colin B. Macdonald
 %%
 %% This file is part of OctSymPy.
 %%
@@ -94,7 +94,7 @@ function L = limit(f, x, a, dir)
 end
 
 
-%!error <Invalid> limit (sym(1), 2, 3, 4, 5)
+%!error limit (sym(1), 2, 3, 4, 5)
 
 %!shared x, oo
 %! syms x

--- a/inst/@sym/log.m
+++ b/inst/@sym/log.m
@@ -1,4 +1,4 @@
-%% Copyright (C) 2014-2016 Colin B. Macdonald
+%% Copyright (C) 2014-2022 Colin B. Macdonald
 %%
 %% This file is part of OctSymPy.
 %%
@@ -44,7 +44,7 @@ function y = log(x)
 end
 
 
-%!error <Invalid> log (sym(1), 2)
+%!error log (sym(1), 2)
 %!assert (isequaln (log (sym(nan)), sym(nan)))
 
 %!shared x, d

--- a/inst/@sym/logint.m
+++ b/inst/@sym/logint.m
@@ -1,4 +1,4 @@
-%% Copyright (C) 2016 Colin B. Macdonald
+%% Copyright (C) 2016-2022 Colin B. Macdonald
 %%
 %% This file is part of OctSymPy.
 %%
@@ -44,7 +44,7 @@ function y = logint(x)
 end
 
 
-%!error <Invalid> logint (sym(1), 2)
+%!error logint (sym(1), 2)
 %!xtest
 %! assert (isequaln (logint (sym(nan)), sym(nan)))
 

--- a/inst/@sym/mod.m
+++ b/inst/@sym/mod.m
@@ -1,4 +1,4 @@
-%% Copyright (C) 2014-2016, 2018 Colin B. Macdonald
+%% Copyright (C) 2014-2016, 2018, 2022 Colin B. Macdonald
 %%
 %% This file is part of OctSymPy.
 %%
@@ -100,7 +100,7 @@ function z = mod(x, n, canpoly)
 end
 
 
-%!error <Invalid> mod (sym(1), 2, 3 ,4)
+%!error mod (sym(1), 2, 3 ,4)
 
 %!assert (isequal (mod (sym(5), 4), sym(1)))
 %!assert (isequal (mod ([sym(5) 8], 4), [1 0] ))

--- a/inst/@sym/numden.m
+++ b/inst/@sym/numden.m
@@ -1,4 +1,4 @@
-%% Copyright (C) 2015, 2016, 2018-2019 Colin B. Macdonald
+%% Copyright (C) 2015, 2016, 2018-2019, 2022 Colin B. Macdonald
 %%
 %% This file is part of OctSymPy.
 %%
@@ -94,7 +94,7 @@ function [N, D] = numden (f)
 end
 
 
-%!error <Invalid> numden (sym(1), 2)
+%!error numden (sym(1), 2)
 
 %!test
 %! syms x

--- a/inst/@sym/permute.m
+++ b/inst/@sym/permute.m
@@ -1,4 +1,4 @@
-%% Copyright (C) 2015, 2016, 2018 Colin B. Macdonald
+%% Copyright (C) 2015, 2016, 2018, 2022 Colin B. Macdonald
 %%
 %% This file is part of OctSymPy.
 %%
@@ -59,7 +59,8 @@ function B = permute(A, perm)
 end
 
 
-%!error <Invalid> permute (sym(1))
+%!error permute (sym(1))
+%!error permute (sym(1), 2, 3)
 
 %!test
 %! D = round(10*rand(5,3));

--- a/inst/@sym/pochhammer.m
+++ b/inst/@sym/pochhammer.m
@@ -67,8 +67,8 @@ function I = pochhammer(x, n)
 end
 
 
-%!error <Invalid> pochhammer (sym(1))
-%!error <Invalid> pochhammer (sym(1), 2, 3)
+%!error pochhammer (sym(1))
+%!error pochhammer (sym(1), 2, 3)
 
 %!assert (isequal (pochhammer (sym(3), 4), sym(360)))
 %!assert (isequal (pochhammer (sym([2 3]), 3), sym([24 60])))

--- a/inst/@sym/potential.m
+++ b/inst/@sym/potential.m
@@ -1,4 +1,4 @@
-%% Copyright (C) 2014-2016, 2019 Colin B. Macdonald
+%% Copyright (C) 2014-2016, 2019, 2022 Colin B. Macdonald
 %%
 %% This file is part of OctSymPy.
 %%
@@ -103,7 +103,7 @@ function p = potential(v, x, y)
 end
 
 
-%!error <Invalid> potential (sym(1), 2, 3, 4)
+%!error potential (sym(1), 2, 3, 4)
 
 %!shared x,y,z
 %! syms x y z

--- a/inst/@sym/prod.m
+++ b/inst/@sym/prod.m
@@ -1,4 +1,4 @@
-%% Copyright (C) 2014-2016, 2019 Colin B. Macdonald
+%% Copyright (C) 2014-2016, 2019, 2022 Colin B. Macdonald
 %%
 %% This file is part of OctSymPy.
 %%
@@ -90,8 +90,8 @@ function y = prod(x, n)
 end
 
 
-%!error <Invalid> prod (sym(1), 2, 3)
-%!error <Invalid> prod (sym(1), 42)
+%!error prod (sym(1), 2, 3)
+%!error prod (sym(1), 42)
 
 %!shared x,y,z
 %! syms x y z

--- a/inst/@sym/qr.m
+++ b/inst/@sym/qr.m
@@ -108,7 +108,7 @@
 %% @end deftypemethod
 
 
-function [Q, R] = qr(A, ord)
+function [varargout] = qr(A, ord)
 
   if (nargin == 2)
     assert (ord == 0, 'OctSymPy:NotImplemented', 'Matrix "B" form not implemented')
@@ -133,10 +133,18 @@ function [Q, R] = qr(A, ord)
   [Q, R] = pycall_sympy__ (cmd, sym(A));
 
   if (nargout <= 1)
-    Q = R;
+    varargout{1} = R;
+  else
+    varargout{1} = Q;
+    varargout{2} = R;
   end
 end
 
+
+%!error qr (sym(1), 2, 3)
+
+%!error <not implemented> [Q, R, P] = qr (sym(1))
+%!error <not implemented> qr (sym(1), 1)
 
 %!test
 %! % scalar
@@ -205,6 +213,3 @@ end
 %!test
 %! % single return value R not Q
 %! assert (isequal (qr (sym(4)), sym(4)))
-
-%!error <not implemented>
-%! [Q, R, P] = qr (sym(1))

--- a/inst/@sym/sec.m
+++ b/inst/@sym/sec.m
@@ -1,4 +1,4 @@
-%% Copyright (C) 2014-2016 Colin B. Macdonald
+%% Copyright (C) 2014-2022 Colin B. Macdonald
 %%
 %% This file is part of OctSymPy.
 %%
@@ -44,7 +44,7 @@ function y = sec(x)
 end
 
 
-%!error <Invalid> sec (sym(1), 2)
+%!error sec (sym(1), 2)
 %!assert (isequaln (sec (sym(nan)), sym(nan)))
 
 %!shared x, d

--- a/inst/@sym/sech.m
+++ b/inst/@sym/sech.m
@@ -1,4 +1,4 @@
-%% Copyright (C) 2016 Colin B. Macdonald
+%% Copyright (C) 2016-2022 Colin B. Macdonald
 %%
 %% This file is part of OctSymPy.
 %%
@@ -44,7 +44,7 @@ function y = sech(x)
 end
 
 
-%!error <Invalid> sech (sym(1), 2)
+%!error sech (sym(1), 2)
 %!assert (isequaln (sech (sym(nan)), sym(nan)))
 
 %!shared x, d

--- a/inst/@sym/sign.m
+++ b/inst/@sym/sign.m
@@ -1,4 +1,4 @@
-%% Copyright (C) 2014-2016 Colin B. Macdonald
+%% Copyright (C) 2014-2022 Colin B. Macdonald
 %%
 %% This file is part of OctSymPy.
 %%
@@ -44,7 +44,7 @@ function y = sign(x)
 end
 
 
-%!error <Invalid> sign (sym(1), 2)
+%!error sign (sym(1), 2)
 %!assert (isequaln (sign (sym(nan)), sym(nan)))
 
 %!shared x, d

--- a/inst/@sym/sin.m
+++ b/inst/@sym/sin.m
@@ -1,4 +1,4 @@
-%% Copyright (C) 2014-2016 Colin B. Macdonald
+%% Copyright (C) 2014-2022 Colin B. Macdonald
 %%
 %% This file is part of OctSymPy.
 %%
@@ -44,7 +44,7 @@ function y = sin(x)
 end
 
 
-%!error <Invalid> sin (sym(1), 2)
+%!error sin (sym(1), 2)
 %!assert (isequaln (sin (sym(nan)), sym(nan)))
 
 %!shared x, d

--- a/inst/@sym/sinc.m
+++ b/inst/@sym/sinc.m
@@ -82,7 +82,7 @@ function y = sinc(x)
 end
 
 
-%!error <Invalid> sinc (sym(1), 2)
+%!error sinc (sym(1), 2)
 %!assert (isequaln (sinc (sym(nan)), sym(nan)))
 
 %!assert (isequal (sinc (sym(0)), sym(1)))

--- a/inst/@sym/sind.m
+++ b/inst/@sym/sind.m
@@ -1,4 +1,4 @@
-%% Copyright (C) 2014-2016 Colin B. Macdonald
+%% Copyright (C) 2014-2016, 2022 Colin B. Macdonald
 %%
 %% This file is part of OctSymPy.
 %%
@@ -48,7 +48,7 @@ function y = sind(x)
 end
 
 
-%!error <Invalid> sind (sym(1), 2)
+%!error sind (sym(1), 2)
 %!assert (isequaln (sind (sym(nan)), sym(nan)))
 
 %!test

--- a/inst/@sym/sinh.m
+++ b/inst/@sym/sinh.m
@@ -1,4 +1,4 @@
-%% Copyright (C) 2014-2016 Colin B. Macdonald
+%% Copyright (C) 2014-2022 Colin B. Macdonald
 %%
 %% This file is part of OctSymPy.
 %%
@@ -44,7 +44,7 @@ function y = sinh(x)
 end
 
 
-%!error <Invalid> sinh (sym(1), 2)
+%!error sinh (sym(1), 2)
 %!assert (isequaln (sinh (sym(nan)), sym(nan)))
 
 %!shared x, d

--- a/inst/@sym/sinhint.m
+++ b/inst/@sym/sinhint.m
@@ -1,4 +1,4 @@
-%% Copyright (C) 2016 Colin B. Macdonald
+%% Copyright (C) 2016-2022 Colin B. Macdonald
 %%
 %% This file is part of OctSymPy.
 %%
@@ -44,7 +44,7 @@ function y = sinhint(x)
 end
 
 
-%!error <Invalid> sinhint (sym(1), 2)
+%!error sinhint (sym(1), 2)
 %!xtest
 %! assert (isequaln (sinhint (sym(nan)), sym(nan)))
 

--- a/inst/@sym/sinint.m
+++ b/inst/@sym/sinint.m
@@ -1,4 +1,4 @@
-%% Copyright (C) 2016 Colin B. Macdonald
+%% Copyright (C) 2016-2022 Colin B. Macdonald
 %%
 %% This file is part of OctSymPy.
 %%
@@ -44,7 +44,7 @@ function y = sinint(x)
 end
 
 
-%!error <Invalid> sinint (sym(1), 2)
+%!error sinint (sym(1), 2)
 %!xtest
 %! assert (isequaln (sinint (sym(nan)), sym(nan)))
 

--- a/inst/@sym/sort.m
+++ b/inst/@sym/sort.m
@@ -1,5 +1,5 @@
 %% Copyright (C) 2016 Utkarsh Gautam
-%% Copyright (C) 2019 Colin B. Macdonald
+%% Copyright (C) 2019, 2022 Colin B. Macdonald
 %%
 %% This file is part of OctSymPy.
 %%
@@ -74,7 +74,7 @@ function s = sort(f)
 end
 
 
-%!error <Invalid> sort (sym(1), 2)
+%!error sort (sym(1), 2)
 
 %!test
 %! f = [sym(1), sym(0)];

--- a/inst/@sym/sqrt.m
+++ b/inst/@sym/sqrt.m
@@ -1,4 +1,4 @@
-%% Copyright (C) 2014-2016 Colin B. Macdonald
+%% Copyright (C) 2014-2022 Colin B. Macdonald
 %%
 %% This file is part of OctSymPy.
 %%
@@ -47,7 +47,7 @@ function y = sqrt(x)
 end
 
 
-%!error <Invalid> sqrt (sym(1), 2)
+%!error sqrt (sym(1), 2)
 %!assert (isequaln (sqrt (sym(nan)), sym(nan)))
 
 %!shared x, d

--- a/inst/@sym/subs.m
+++ b/inst/@sym/subs.m
@@ -271,7 +271,7 @@ function g = subs(f, in, out)
 end
 
 
-%!error <Invalid> subs (sym(1), 2, 3, 4)
+%!error subs (sym(1), 2, 3, 4)
 
 %!shared x,y,t,f
 %! syms x y t

--- a/inst/@sym/sum.m
+++ b/inst/@sym/sum.m
@@ -1,4 +1,4 @@
-%% Copyright (C) 2014-2016, 2019 Colin B. Macdonald
+%% Copyright (C) 2014-2016, 2019, 2022 Colin B. Macdonald
 %%
 %% This file is part of OctSymPy.
 %%
@@ -84,8 +84,8 @@ function y = sum(x, n)
 end
 
 
-%!error <Invalid> sum (sym(1), 2, 3)
-%!error <Invalid> sum (sym(1), 42)
+%!error sum (sym(1), 2, 3)
+%!error sum (sym(1), 42)
 
 %!shared x,y,z
 %! syms x y z

--- a/inst/@sym/symprod.m
+++ b/inst/@sym/symprod.m
@@ -1,4 +1,4 @@
-%% Copyright (C) 2014-2016, 2019 Colin B. Macdonald
+%% Copyright (C) 2014-2016, 2019, 2022 Colin B. Macdonald
 %%
 %% This file is part of OctSymPy.
 %%
@@ -126,7 +126,7 @@ function S = symprod(f, n, a, b)
 end
 
 
-%!error <Invalid> symprod (sym(1), 2, 3, 4, 5)
+%!error symprod (sym(1), 2, 3, 4, 5)
 
 %!test
 %! % simple

--- a/inst/@sym/symsum.m
+++ b/inst/@sym/symsum.m
@@ -1,4 +1,4 @@
-%% Copyright (C) 2014-2016, 2019 Colin B. Macdonald
+%% Copyright (C) 2014-2016, 2019, 2022 Colin B. Macdonald
 %%
 %% This file is part of OctSymPy.
 %%
@@ -121,7 +121,7 @@ function S = symsum(f, n, a, b)
 end
 
 
-%!error <Invalid> symsum (sym(1), 2, 3, 4, 5)
+%!error symsum (sym(1), 2, 3, 4, 5)
 
 %!test
 %! % finite sums

--- a/inst/@sym/symvar.m
+++ b/inst/@sym/symvar.m
@@ -1,4 +1,4 @@
-%% Copyright (C) 2014-2016 Colin B. Macdonald
+%% Copyright (C) 2014-2016, 2022 Colin B. Macdonald
 %%
 %% This file is part of OctSymPy.
 %%
@@ -145,7 +145,7 @@ function vars = symvar(F, Nout)
 end
 
 
-%!error <usage> symvar (sym(1), 2, 3)
+%!error symvar (sym(1), 2, 3)
 
 %!test
 %! %% some empty cases

--- a/inst/@sym/tan.m
+++ b/inst/@sym/tan.m
@@ -1,4 +1,4 @@
-%% Copyright (C) 2014-2016 Colin B. Macdonald
+%% Copyright (C) 2014-2022 Colin B. Macdonald
 %%
 %% This file is part of OctSymPy.
 %%
@@ -44,7 +44,7 @@ function y = tan(x)
 end
 
 
-%!error <Invalid> tan (sym(1), 2)
+%!error tan (sym(1), 2)
 %!assert (isequaln (tan (sym(nan)), sym(nan)))
 
 %!shared x, d

--- a/inst/@sym/tand.m
+++ b/inst/@sym/tand.m
@@ -1,4 +1,4 @@
-%% Copyright (C) 2014-2016 Colin B. Macdonald
+%% Copyright (C) 2014-2016, 2022 Colin B. Macdonald
 %%
 %% This file is part of OctSymPy.
 %%
@@ -48,7 +48,7 @@ function y = tand(x)
 end
 
 
-%!error <Invalid> tand (sym(1), 2)
+%!error tand (sym(1), 2)
 %!assert (isequaln (tand (sym(nan)), sym(nan)))
 
 %!test

--- a/inst/@sym/tanh.m
+++ b/inst/@sym/tanh.m
@@ -1,4 +1,4 @@
-%% Copyright (C) 2014-2016 Colin B. Macdonald
+%% Copyright (C) 2014-2022 Colin B. Macdonald
 %%
 %% This file is part of OctSymPy.
 %%
@@ -44,7 +44,7 @@ function y = tanh(x)
 end
 
 
-%!error <Invalid> tanh (sym(1), 2)
+%!error tanh (sym(1), 2)
 %!assert (isequaln (tanh (sym(nan)), sym(nan)))
 
 %!shared x, d

--- a/inst/@sym/zeta.m
+++ b/inst/@sym/zeta.m
@@ -1,4 +1,4 @@
-%% Copyright (C) 2016, 2018-2019 Colin B. Macdonald
+%% Copyright (C) 2016, 2018-2019, 2022 Colin B. Macdonald
 %% Copyright (C) 2016 Lagu
 %%
 %% This file is part of OctSymPy.
@@ -73,7 +73,7 @@ function y = zeta(n, z)
 end
 
 
-%!error <Invalid> zeta (sym(1), 2, 3)
+%!error zeta (sym(1), 2, 3)
 %!assert (isequaln (zeta (sym(nan)), sym(nan)))
 
 %!test

--- a/inst/@symfun/symfun.m
+++ b/inst/@symfun/symfun.m
@@ -195,7 +195,7 @@ function f = symfun(expr, vars)
 end
 
 
-%!error <Invalid> symfun (1, sym('x'), 3)
+%!error symfun (1, sym('x'), 3)
 
 %!error <not supported> symfun ('f', sym('x'))
 

--- a/inst/assume.m
+++ b/inst/assume.m
@@ -1,4 +1,4 @@
-%% Copyright (C) 2017 Colin B. Macdonald
+%% Copyright (C) 2017, 2022 Colin B. Macdonald
 %%
 %% This file is part of OctSymPy.
 %%
@@ -58,7 +58,7 @@
 %% @end deffn
 
 
-function assume(varargin)
+function varargout = assume(varargin)
 
   assert (nargout == 0, 'assume: use functional form if you want output');
 

--- a/inst/catalan.m
+++ b/inst/catalan.m
@@ -1,5 +1,5 @@
 %% Copyright (C) 2015 Carnë Draug
-%% Copyright (C) 2016, 2018-2019 Colin B. Macdonald
+%% Copyright (C) 2016, 2018-2019, 2022 Colin B. Macdonald
 %% Copyright (C) 2022 Chris Gorman
 %%
 %% This file is part of OctSymPy.
@@ -50,6 +50,6 @@ function g = catalan ()
 end
 
 
-%!error <Invalid> catalan (sym(1))
+%!error catalan (sym(1))
 %!assert (double (catalan ()) > 0.915965594177)
 %!assert (double (catalan ()) < 0.915965594178)

--- a/inst/eulergamma.m
+++ b/inst/eulergamma.m
@@ -1,5 +1,5 @@
 %% Copyright (C) 2015 Carnë Draug
-%% Copyright (C) 2016, 2018-2019 Colin B. Macdonald
+%% Copyright (C) 2016, 2018-2019, 2022 Colin B. Macdonald
 %%
 %% This file is part of OctSymPy.
 %%
@@ -48,6 +48,6 @@ function g = eulergamma ()
 end
 
 
-%!error <Invalid> catalan (sym(1))
+%!error catalan (sym(1))
 %!assert (double (eulergamma ()) > 0.577215664901)
 %!assert (double (eulergamma ()) < 0.577215664902)

--- a/inst/laguerreL.m
+++ b/inst/laguerreL.m
@@ -1,6 +1,6 @@
 %% Copyright (C) 2008 Eric Chassande-Mottin
 %% Copyright (C) 2011 Carnë Draug
-%% Copyright (C) 2016, 2018 Colin B. Macdonald
+%% Copyright (C) 2016, 2018, 2022 Colin B. Macdonald
 %%
 %% This program is free software; you can redistribute it and/or modify it under
 %% the terms of the GNU General Public License as published by the Free Software
@@ -118,6 +118,9 @@ function L = laguerreL(n, x)
 end
 
 
+%!error laguerreL (1)
+%!error laguerreL (1, 2, 3)
+
 %!assert (isequal (laguerreL (0, rand), 1))
 
 %!test
@@ -146,7 +149,6 @@ end
 %! assert(y1 - y2, 0, 30*eps)
 
 %!error <positive integer> laguerreL(1.5, 10)
-%!error <Invalid call> laguerreL(10)
 %!error <same size or scalar> laguerreL([0 1], [1 2 3])
 %!error <same size or scalar> laguerreL([0 1], [1; 2])
 

--- a/util/generate_functions.py
+++ b/util/generate_functions.py
@@ -353,6 +353,8 @@ function y = {NAME} (x)
 end
 
 
+%!error {NAME} (1, 2)
+
 %!test
 %! x = 1.1;
 %! y = sym(11)/10;

--- a/util/generate_functions.py
+++ b/util/generate_functions.py
@@ -1,7 +1,7 @@
 #!/bin/env python3
 # -*- coding: utf-8 -*-
 #
-# Copyright 2014-2016 Colin B. Macdonald
+# Copyright 2014-2016, 2022 Colin B. Macdonald
 #
 # Copying and distribution of this file, with or without modification,
 # are permitted in any medium without royalty provided the copyright
@@ -245,7 +245,7 @@ function y = {NAME}(x)
 end
 
 
-%!error <Invalid> {NAME} (sym(1), 2)
+%!error {NAME} (sym(1), 2)
 %!assert (isequaln ({NAME} (sym(nan)), sym(nan)))
 
 """.format(NAME=f, SPNAME=d['spname'], XSTR=xstr, YUTF8=yutf8)


### PR DESCRIPTION
CI: run BIST on Octave 7.1.0

Lots of changes for new and different error messages when too many inputs.