### PR TITLE
sympref diagnose: Show information about the current system.

### DIFF
--- a/inst/private/assert_have_python_and_sympy.m
+++ b/inst/private/assert_have_python_and_sympy.m
@@ -1,4 +1,5 @@
 %% Copyright (C) 2016-2019, 2022 Colin B. Macdonald
+%% Copyright (C) 2022 Alex Vong
 %%
 %% This file is part of OctSymPy.
 %%
@@ -100,6 +101,8 @@ function assert_have_python_and_sympy (pyexec, verbose)
     [status, output] = system([pyexec ' -c "import sys; print(sys.version)"']);
     status
     output
+    disp ('');
+    show_system_info ();
   end
 
   if (verbose)

--- a/inst/private/assert_pythonic_and_sympy.m
+++ b/inst/private/assert_pythonic_and_sympy.m
@@ -1,4 +1,5 @@
 %% Copyright (C) 2019, 2022 Colin B. Macdonald
+%% Copyright (C) 2022 Alex Vong
 %%
 %% This file is part of OctSymPy.
 %%
@@ -83,6 +84,8 @@ function assert_pythonic_and_sympy (verbose)
     disp ('--------------')
     disp ('')
     pyversion ()
+    disp ('')
+    show_system_info ()
   else
     pyver = pyversion ();
   end

--- a/inst/private/show_system_info.m
+++ b/inst/private/show_system_info.m
@@ -1,0 +1,39 @@
+%% Copyright (C) 2022 Alex Vong
+%%
+%% This file is part of OctSymPy.
+%%
+%% OctSymPy is free software; you can redistribute it and/or modify
+%% it under the terms of the GNU General Public License as published
+%% by the Free Software Foundation; either version 3 of the License,
+%% or (at your option) any later version.
+%%
+%% This software is distributed in the hope that it will be useful,
+%% but WITHOUT ANY WARRANTY; without even the implied warranty
+%% of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See
+%% the GNU General Public License for more details.
+%%
+%% You should have received a copy of the GNU General Public
+%% License along with this software; see the file COPYING.
+%% If not, see <https://www.gnu.org/licenses/>.
+
+%% -*- texinfo -*-
+%% @defun  show_system_info ()
+%% Show information about the current system.
+%%
+%% @seealso{computer, ver}
+%% @end defun
+
+function show_system_info ()
+  [platform, array_maxsize, endian] = computer ();
+  arch = computer ('arch');
+
+  disp ('System info');
+  disp ('-----------');
+  disp ('');
+  fprintf ('Platform: %s\n', platform);
+  fprintf ('Array Maximum Size: %d\n', array_maxsize);
+  fprintf ('Endianness: %s\n', endian);
+  fprintf ('Architecture: %s\n', arch);
+  ver ();
+  disp ('');
+end


### PR DESCRIPTION
Fixes #1127.

* inst/private/show_system_info.m: New function.
* inst/private/assert_have_python_and_sympy.m: Use it.
* inst/private/assert_pythonic_and_sympy.m: Likewise.