### PR TITLE
Fixes #1109

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -56,12 +56,20 @@ jobs:
       fail-fast: true
       matrix:
         octave: [7.1.0]
-        sympy: [1.4, 1.5.1, 1.6.2, 1.7.1, 1.8, 1.10.1]
+        sympy: [1.4, 1.5.1, 1.6.2, 1.7.1, 1.8, 1.9, 1.10.1]
         include:
           - octave: 5.1.0
             sympy: 1.8
           - octave: 5.2.0
             sympy: 1.8
+          - octave: 6.1.0
+            sympy: 1.9
+          - octave: 6.2.0
+            sympy: 1.9
+          - octave: 6.3.0
+            sympy: 1.9
+          - octave: 6.4.0
+            sympy: 1.9
           - octave: 6.1.0
             sympy: 1.10.1
           - octave: 6.2.0
@@ -114,12 +122,14 @@ jobs:
       fail-fast: true
       matrix:
         octave: [7.1.0]
-        sympy: [1.4, 1.5.1, 1.6.2, 1.7.1, 1.8, 1.10.1]
+        sympy: [1.4, 1.5.1, 1.6.2, 1.7.1, 1.8, 1.9, 1.10.1]
         include:
           - octave: 5.1.0
             sympy: 1.8
           - octave: 5.2.0
             sympy: 1.8
+          - octave: 6.4.0
+            sympy: 1.9
           - octave: 6.4.0
             sympy: 1.10.1
     steps:
@@ -170,7 +180,7 @@ jobs:
       fail-fast: false
       matrix:
         octave: [7.1.0]
-        sympy: [1.10.1]
+        sympy: [1.9, 1.10.1]
     steps:
       - uses: actions/checkout@v2
       - name:
@@ -247,7 +257,7 @@ jobs:
       fail-fast: false
       matrix:
         octave: [7.1.0]
-        sympy: [1.10.1]
+        sympy: [1.9, 1.10.1]
     steps:
       - uses: actions/checkout@v2
       - name:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -177,7 +177,7 @@ jobs:
   bist-pythonic:
     runs-on: ubuntu-latest
     strategy:
-      fail-fast: false
+      fail-fast: true
       matrix:
         octave: [7.1.0]
         sympy: [1.9, 1.10.1]
@@ -254,7 +254,7 @@ jobs:
   doctests-pythonic:
     runs-on: ubuntu-latest
     strategy:
-      fail-fast: false
+      fail-fast: true
       matrix:
         octave: [7.1.0]
         sympy: [1.9, 1.10.1]

--- a/inst/@sym/rdivide.m
+++ b/inst/@sym/rdivide.m
@@ -1,4 +1,5 @@
 %% Copyright (C) 2014, 2016, 2018-2019 Colin B. Macdonald
+%% Copyright (C) 2022 Alex Vong
 %%
 %% This file is part of OctSymPy.
 %%
@@ -92,10 +93,18 @@ function z = rdivide(x, y)
     return
   end
 
+  %% 2022-06: TODO cannot simply call hadamard_product for sympy <1.9,
+  %% see upstream: https://github.com/sympy/sympy/issues/8557
 
   cmd = { '(x,y) = _ins'
           'if x.is_Matrix and y.is_Matrix:'
-          '    return x.multiply_elementwise(y.applyfunc(lambda a: 1/a)),'
+          '    y_eltwise_recip = y.applyfunc(lambda a: 1/a)'
+          '    if Version(spver) < Version("1.9"):'
+          '        try:'
+          '            return x.multiply_elementwise(y_eltwise_recip)'
+          '        except:'
+          '            pass'
+          '    return hadamard_product(x, y_eltwise_recip)'
           'if not x.is_Matrix and y.is_Matrix:'
           '    return y.applyfunc(lambda a: x/a),'
           'else:'

--- a/inst/@sym/times.m
+++ b/inst/@sym/times.m
@@ -1,4 +1,5 @@
 %% Copyright (C) 2014, 2016, 2018-2019, 2022 Colin B. Macdonald
+%% Copyright (C) 2022 Alex Vong
 %%
 %% This file is part of OctSymPy.
 %%
@@ -58,17 +59,19 @@ function z = times(x, y)
     return
   end
 
-  % 2018-01: TODO cannot simply call hadamard_product, see upstream:
-  % https://github.com/sympy/sympy/issues/8557
+  %% 2022-06: TODO cannot simply call hadamard_product for sympy <1.9,
+  %% see upstream: https://github.com/sympy/sympy/issues/8557
 
   cmd = { '(x,y) = _ins'
           'if x is None or y is None:'
           '    return x*y'
           'if x.is_Matrix and y.is_Matrix:'
-          '    try:'
-          '        return x.multiply_elementwise(y)'
-          '    except (AttributeError, TypeError):'
-          '        return hadamard_product(x, y)'
+          '    if Version(spver) < Version("1.9"):'
+          '        try:'
+          '            return x.multiply_elementwise(y)'
+          '        except (AttributeError, TypeError):'
+          '            pass'
+          '    return hadamard_product(x, y)'
           'return x*y' };
 
   z = pycall_sympy__ (cmd, sym(x), sym(y));


### PR DESCRIPTION
This PR fixes #1109 by using the workaround only for sympy <1.9 and use `hadamard_product` otherwise.

We also enable tests for sympy 1.9 and enable `fail-fast` for pythonic tests.
