### PR TITLE
@sym/mrdivide: Simplify implementation.

### DIFF
--- a/inst/@sym/mldivide.m
+++ b/inst/@sym/mldivide.m
@@ -1,4 +1,5 @@
 %% Copyright (C) 2014, 2016, 2018-2019 Colin B. Macdonald
+%% Copyright (C) 2022 Alex Vong
 %%
 %% This file is part of OctSymPy.
 %%
@@ -102,7 +103,7 @@ function x = mldivide(A, b)
   %'ans = A.LUsolve(b)'
 
   if (isscalar(A))
-    x = b / A;
+    x = A .\ b;
     return
   end
 

--- a/inst/@sym/mrdivide.m
+++ b/inst/@sym/mrdivide.m
@@ -1,5 +1,6 @@
 %% Copyright (C) 2014, 2016, 2018-2019, 2022 Colin B. Macdonald
 %% Copyright (C) 2022 Chris Gorman
+%% Copyright (C) 2022 Alex Vong
 %%
 %% This file is part of OctSymPy.
 %%
@@ -68,26 +69,7 @@
 
 
 function z = mrdivide(x, y)
-
-  % XXX: delete this when we drop support for Octave < 4.4.2
-  if (isa(x, 'symfun') || isa(y, 'symfun'))
-    warning('OctSymPy:sym:arithmetic:workaround42735', ...
-            'worked around octave bug #42735')
-    z = mrdivide(x, y);
-    return
-  end
-
-  cmd = {
-    '(A, B) = _ins'
-    'if not B.is_Matrix:'
-    '     Z = A / B'
-    'else:'
-    '     Z = B.T.solve(A.T).T'
-    'return (Z)'
-  };
-
-  z = pycall_sympy__ (cmd, sym(x), sym(y));
-
+  z = (y.' \ x.').';
 end
 
 


### PR DESCRIPTION
Use @sym/mldivide instead of running sympy code directly.

Closes #1118.

* inst/@sym/mrdivide.m: Simplify it.
* inst/@sym/mldivide.m: Adjust accordingly to avoid infinite loop.