### PR TITLE
private/store_vars_in_python: Fixes regression...

### DIFF
--- a/inst/private/store_vars_in_python.m
+++ b/inst/private/store_vars_in_python.m
@@ -26,7 +26,7 @@ function var_pyobj = store_vars_in_python (L)
       var_pyobj.append (pyeval (sympy (x)))
     elseif (iscell (x))
       var_pyobj.append (store_vars_in_python (x))
-    elseif (isequal (x, []))
+    elseif (isnumeric (x) && isequal (x, [])) % See #1151 for more details
       var_pyobj.append (py.list ());
     else
       var_pyobj.append(x);

--- a/inst/pycall_sympy__.m
+++ b/inst/pycall_sympy__.m
@@ -481,3 +481,7 @@ end
 %! % ensure the 0x0 matrix in octave gets mapped to the empty list in python
 %! % @sym/subsasgn currently replies on this behaviour
 %! assert (pycall_sympy__ ('return _ins[0] == []', []));
+
+%!test
+%! % ensure the empty string gets mapped to the empty string in python
+%! assert (pycall_sympy__ ('return _ins[0] == ""', ''));


### PR DESCRIPTION
...caused by cd263b3853482226dbffe99486ff98c8445d6a63.

Closes #1151.

* inst/private/store_vars_in_python.m: Update it.
* inst/pycall_sympy__.m: Add test accordingly.