### PR TITLE
@sym/ztrans: Temporarily remove reference to unimplemented function.

### DIFF
--- a/inst/@sym/ztrans.m
+++ b/inst/@sym/ztrans.m
@@ -269,7 +269,6 @@
 %% @end group
 %% @end example
 %%
-%% @seealso{@@sym/iztrans}
 %% @end defmethod
 
 %% Author: Alex Vong


### PR DESCRIPTION
We will add it back after we implement @sym/iztrans.

Closes #1122.

* inst/@sym/ztrans.m: Remove reference.