### PR TITLE
Add .oct-config to indicate source is in utf-8

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -6,6 +6,11 @@ octsympy 3.0.0+
 
           adjoint
 
+  * Misc bug fixes and improvements in error handling.
+
+  * `.oct-config` files indicate source is UTF-8 encoded and should improve
+    any locale or encoding problems on Octave 7 and above.
+
 
 
 octsympy 3.0.0 (2022-07-05)

--- a/inst/.oct-config
+++ b/inst/.oct-config
@@ -1,0 +1,1 @@
+encoding=utf-8

--- a/misc/.oct-config
+++ b/misc/.oct-config
@@ -1,0 +1,1 @@
+encoding=utf-8

--- a/util/.oct-config
+++ b/util/.oct-config
@@ -1,0 +1,1 @@
+encoding=utf-8


### PR DESCRIPTION
These are not needed inside `@class` and `private` directories.
Fixes Issue #1191.