### PR TITLE
Fixes #1009

### DIFF
--- a/inst/private/assert_have_python_and_sympy.m
+++ b/inst/private/assert_have_python_and_sympy.m
@@ -97,8 +97,8 @@ function assert_have_python_and_sympy (pyexec, verbose)
     disp ('')
     disp ('Let''s check what version of Python we are calling...')
     disp ('')
-    fprintf ('Attempting to run %s -c "import sys; print(sys.version)"\n\n', pyexec);
-    [status, output] = system([pyexec ' -c "import sys; print(sys.version)"']);
+    fprintf ('Attempting to run %s -c "import sys; print(); print(''version: '' + sys.version); print(''executable: '' + sys.executable)"\n\n', pyexec);
+    [status, output] = system([pyexec ' -c "import sys; print(); print(''version: '' + sys.version); print(''executable: '' + sys.executable)"']);
     status
     output
     disp ('');

--- a/inst/private/assert_have_python_and_sympy.m
+++ b/inst/private/assert_have_python_and_sympy.m
@@ -101,6 +101,12 @@ function assert_have_python_and_sympy (pyexec, verbose)
     [status, output] = system([pyexec ' -c "import sys; print(); print(''version: '' + sys.version); print(''executable: '' + sys.executable)"']);
     status
     output
+    fprintf ('Checking if %s is running in a Cygwin-like POSIX environment...', pyexec);
+    if python_env_is_cygwin_like (pyexec)
+      fprintf (' yes\n\n');
+    else
+      fprintf (' no\n\n');
+    end
     disp ('');
     show_system_info ();
   end

--- a/inst/private/assert_have_python_and_sympy.m
+++ b/inst/private/assert_have_python_and_sympy.m
@@ -97,9 +97,12 @@ function assert_have_python_and_sympy (pyexec, verbose)
     disp ('')
     disp ('Let''s check what version of Python we are calling...')
     disp ('')
-    fprintf ('Attempting to run %s -c "import sys; print(); print(''version: '' + sys.version); print(''executable: '' + sys.executable)"\n\n', pyexec);
-    [status, output] = system([pyexec ' -c "import sys; print(); print(''version: '' + sys.version); print(''executable: '' + sys.executable)"']);
+    fprintf ('Attempting to run %s -c "import sys; print(sys.version)"\n', pyexec);
+    [status, output] = system ([pyexec ' -c "import sys; print(sys.version)"']);
     status
+    output
+    fprintf ('Running %s -c "import sys; print(sys.executable)"\n', pyexec);
+    [status, output] = system ([pyexec ' -c "import sys; print(sys.executable)"']);
     output
     fprintf ('Checking if %s is running in a Cygwin-like POSIX environment...', pyexec);
     if python_env_is_cygwin_like (pyexec)


### PR DESCRIPTION
This PR fixes #1009 by updating `inst/private/assert_have_python_and_sympy.m` so that `sympref diagnose`

1. Show full path of Python executable when using non-Pythonic IPC.
2. Detect if Python is running in a Cygwin-like POSIX environment when using non-Pythonic IPC.
