### PR TITLE
Make *cat Array-compatible

### DIFF
--- a/inst/@sym/horzcat.m
+++ b/inst/@sym/horzcat.m
@@ -46,25 +46,8 @@
 
 function h = horzcat(varargin)
 
-  % special case for 0x0 but other empties should be checked for
-  % compatibilty
-  cmd = {
-          '_proc = []'
-          'for i in _ins:'
-          '    if i is None or not i.is_Matrix:'
-          '        _proc.append(sp.Matrix([[i]]))'
-          '    else:'
-          '        if i.shape == (0, 0):'
-          '            pass'
-          '        else:'
-          '            _proc.append(i)'
-          'return sp.MatrixBase.hstack(*_proc),'
-          };
-
-  for i = 1:nargin
-    varargin{i} = sym(varargin{i});
-  end
-  h = pycall_sympy__ (cmd, varargin{:});
+  args = cellfun (@transpose, varargin, 'UniformOutput', false);
+  h = vertcat (args{:}).';
 
 end
 

--- a/inst/@sym/horzcat.m
+++ b/inst/@sym/horzcat.m
@@ -1,4 +1,5 @@
 %% Copyright (C) 2014-2017, 2019 Colin B. Macdonald
+%% Copyright (C) 2022 Alex Vong
 %%
 %% This file is part of OctSymPy.
 %%
@@ -21,7 +22,7 @@
 %% @defop  Method   @@sym {horzcat} {(@var{x}, @var{y}, @dots{})}
 %% @defopx Operator @@sym {[@var{x}, @var{y}, @dots{}]} {}
 %% @defopx Operator @@sym {[@var{x} @var{y} @dots{}]} {}
-%% Horizontally concatentate symbolic arrays.
+%% Horizontally concatenate symbolic arrays.
 %%
 %% Example:
 %% @example

--- a/inst/@sym/transpose.m
+++ b/inst/@sym/transpose.m
@@ -1,4 +1,5 @@
 %% Copyright (C) 2014-2016, 2019 Colin B. Macdonald
+%% Copyright (C) 2022 Alex Vong
 %%
 %% This file is part of OctSymPy.
 %%
@@ -66,8 +67,11 @@ function z = transpose(x)
   end
 
   cmd = { 'x = _ins[0]'
-          'if x.is_Matrix:'
+          'if isinstance(x, MatrixBase):'
           '    return x.T'
+          'elif isinstance(x, NDimArray):'
+          '    xx = x.tolist()'
+          '    return make_matrix_or_array(list(zip(*xx)))'
           'else:'
           '    return x' };
 
@@ -92,3 +96,8 @@ end
 %!test
 %! A = [1 2] + 1i;
 %! assert(isequal( sym(A).' , sym(A.') ))
+
+%!test
+%! % see https://github.com/cbm755/octsympy/issues/1215
+%! none = pycall_sympy__ ('return None');
+%! assert (isequal (none.', none));

--- a/inst/@sym/vertcat.m
+++ b/inst/@sym/vertcat.m
@@ -45,23 +45,25 @@ function h = vertcat(varargin)
 
   % special case for 0x0 but other empties should be checked for
   % compatibilty
-  cmd = {
-          '_proc = []'
-          'for i in _ins:'
-          '    if i is None or not i.is_Matrix:'
-          '        _proc.append(sp.Matrix([[i]]))'
-          '    else:'
-          '        if i.shape == (0, 0):'
-          '            pass'
-          '        else:'
-          '            _proc.append(i)'
-          'return sp.MatrixBase.vstack(*_proc),'
-          };
+  cmd = {'def is_matrix_or_array(x):'
+         '    return isinstance(x, (MatrixBase, NDimArray))'
+         'def number_of_columns(x):'
+         '    return x.shape[1] if is_matrix_or_array(x) else 1'
+         'def all_equal(*ls):'
+         '    return True if ls == [] else all(ls[0] == x for x in ls[1:])'
+         'def as_list_of_list(x):'
+         '    return x.tolist() if is_matrix_or_array(x) else [[x]]'
+         'args = [x for x in _ins if x != zeros(0, 0)] # remove 0x0 matrices'
+         'ncols = [number_of_columns(x) for x in args]'
+         'if not all_equal(*ncols):'
+         '    msg = "vertcat: all inputs must have the same number of columns"'
+         '    raise ShapeError(msg)'
+         'CCC = [as_list_of_list(x) for x in args]'
+         'CC = list(itertools.chain.from_iterable(CCC))'
+         'return make_matrix_or_array(CC)'};
 
-  for i = 1:nargin
-    varargin{i} = sym(varargin{i});
-  end
-  h = pycall_sympy__ (cmd, varargin{:});
+  args = cellfun (@sym, varargin, 'UniformOutput', false);
+  h = pycall_sympy__ (cmd, args{:});
 
 end
 

--- a/inst/@sym/vertcat.m
+++ b/inst/@sym/vertcat.m
@@ -1,4 +1,5 @@
 %% Copyright (C) 2014-2017, 2019 Colin B. Macdonald
+%% Copyright (C) 2022 Alex Vong
 %%
 %% This file is part of OctSymPy.
 %%
@@ -20,7 +21,7 @@
 %% @documentencoding UTF-8
 %% @defop  Method   @@sym {vertcat} {(@var{x}, @var{y}, @dots{})}
 %% @defopx Operator @@sym {[@var{x}; @var{y}; @dots{}]} {}
-%% Vertically concatentate symbolic arrays.
+%% Vertically concatenate symbolic arrays.
 %%
 %% Example:
 %% @example


### PR DESCRIPTION
This PR makes `@sym/vertcat`, `@sym/horzcat` and `@sym/tranpose` Array-compatible.

In `@sym/horzcat`, we make use of the property that

```
[A_1; A_2; ...; A_n).' == [A_1.' A_2.' ... A_n.']
```
for all `A_k` with compatible sizes.
