### PR TITLE
@sym/repmat: Re-implement function without using 'pycall_sympy__'.

### DIFF
--- a/inst/@sym/private/mat_rclist_access.m
+++ b/inst/@sym/private/mat_rclist_access.m
@@ -33,8 +33,7 @@ function z = mat_rclist_access(A, r, c)
     error('this routine is for a list of rows and cols');
   end
 
-  cmd = {'dbg_no_array = True'
-         '(A, rr, cc) = _ins'
+  cmd = {'(A, rr, cc) = _ins'
          'AA = A.tolist() if isinstance(A, (MatrixBase, NDimArray)) else [[A]]'
          'MM = [[AA[i][j]] for i, j in zip(rr, cc)]'
          'M = make_matrix_or_array(MM)'

--- a/inst/@sym/private/mat_rclist_asgn.m
+++ b/inst/@sym/private/mat_rclist_asgn.m
@@ -60,8 +60,7 @@ function z = mat_rclist_asgn(A, r, c, B)
   %    AA[0, 0] = A
   % Also usefil: .copyin_matrix
 
-  cmd = {'dbg_no_array = True'
-         '(A, rr, cc, b) = _ins'
+  cmd = {'(A, rr, cc, b) = _ins'
          'assert A == [] or not isinstance(A, list), "unexpectedly non-empty list: report bug!"'
          'if A == []:'
          '    AA = []'


### PR DESCRIPTION
This PR mainly re-implements `@sym/repmat` without using `pycall_sympy__`. It has the advantage of making the function compatible with non-Matrix 2D sym. It also fixes #1218 at the same time.
