### PR TITLE
subs: use make_matrix_or_array and use 2-d indexing

### DIFF
--- a/inst/@sym/private/mat_rclist_asgn.m
+++ b/inst/@sym/private/mat_rclist_asgn.m
@@ -80,7 +80,7 @@ function z = mat_rclist_asgn(A, r, c, B)
          '    elif i < nrows_A and j < ncols_A:'
          '        return AA[i][j]'
          '    else:'
-         '        return 0'
+         '        return S.Zero'
          'n = max(max(rr) + 1, nrows_A)'
          'm = max(max(cc) + 1, ncols_A)'
          'MM = [[entry(i, j) for j in range(m)] for i in range(n)]'

--- a/inst/@sym/reshape.m
+++ b/inst/@sym/reshape.m
@@ -1,4 +1,4 @@
-%% Copyright (C) 2014, 2016, 2019 Colin B. Macdonald
+%% Copyright (C) 2014, 2016, 2019, 2022 Colin B. Macdonald
 %%
 %% This file is part of OctSymPy.
 %%
@@ -75,9 +75,10 @@ function z = reshape(a, n, m)
 
   cmd = {
       '(A, n, m) = _ins'
-      'if A is not None and A.is_Matrix:'
-      '    #sympy is row-based'
-      '    return A.T.reshape(m,n).T'
+      'if isinstance(A, (MatrixBase, NDimArray)):'
+      '    #sympy is row-based, but Array does not have .T'
+      '    #return A.T.reshape(m,n).T'
+      '    return transpose(transpose(A).reshape(m, n))'
       'else:'
       '    if n != 1 or m != 1:'
       '        raise ValueError("cannot reshape scalar to non-1x1 size")'

--- a/inst/@sym/subs.m
+++ b/inst/@sym/subs.m
@@ -256,14 +256,14 @@ function g = subs(f, in, out)
     'sizes = {(a.shape if a.is_Matrix else (1, 1)) for a in yy}'
     'sizes.discard((1, 1))'
     'assert len(sizes) == 1, "all substitions must be same size or scalar"'
-    'size = sizes.pop()'
-    'numel = prod(size)'
-    'g = [0]*numel'
-    'for i in range(len(g)):'
-    '    yyy = [y[i] if y.is_Matrix else y for y in yy]'
-    '    sublist = list(zip(xx, yyy))'
-    '    g[i] = f.subs(sublist, simultaneous=True).doit()'
-    'return Matrix(*size, g)'
+    'm, n = sizes.pop()'
+    'g = [[0]*n for i in range(m)]'
+    'for i in range(m):'
+    '    for j in range(n):'
+    '        yyy = [y[i, j] if y.is_Matrix else y for y in yy]'
+    '        sublist = list(zip(xx, yyy))'
+    '        g[i][j] = f.subs(sublist, simultaneous=True).doit()'
+    'return make_matrix_or_array(g)'
   };
 
   g = pycall_sympy__ (cmd, f, in, out);


### PR DESCRIPTION
Fixes Issue #1226.  Related to Issue #1222.

This makes `test @sym/and`, or, etc pass.