### PR TITLE
subs/vertcat: after Array port was creating incorrect empties

### DIFF
--- a/inst/@sym/horzcat.m
+++ b/inst/@sym/horzcat.m
@@ -1,4 +1,4 @@
-%% Copyright (C) 2014-2017, 2019 Colin B. Macdonald
+%% Copyright (C) 2014-2017, 2019, 2022 Colin B. Macdonald
 %% Copyright (C) 2022 Alex Vong
 %%
 %% This file is part of OctSymPy.
@@ -117,8 +117,37 @@ end
 %! q = sym(ones(3, 0));
 %! w = horzcat(v, q);
 
+%!error <ShapeError>
+%! z30 = sym (zeros (3, 0));
+%! z40 = sym (zeros (4, 0));
+%! % Note Issue #1238: unclear error message:
+%! % [z30 z40];
+%! % but this gives the ShapeError
+%! horzcat(z30, z40);
+
+%!test
+%! % special case for the 0x0 empty: no error
+%! z00 = sym (zeros (0, 0));
+%! z30 = sym (zeros (3, 0));
+%! [z00 z30];
+
 %!test
 %! % issue #700
 %! A = sym ([1 2]);
 %! B = simplify (A);
 %! assert (isequal ([B A], [A B]))
+
+%!test
+%! % issue #1236, correct empty sizes
+%! syms x
+%! z00 = sym (zeros (0, 0));
+%! z30 = sym (zeros (3, 0));
+%! z03 = sym (zeros (0, 3));
+%! z04 = sym (zeros (0, 4));
+%! assert (size ([z00 z00]), [0 0])
+%! assert (size ([z00 z03]), [0 3])
+%! assert (size ([z03 z03]), [0 6])
+%! assert (size ([z03 z04]), [0 7])
+%! assert (size ([z03 z00 z04]), [0 7])
+%! assert (size ([z30 z30]), [3 0])
+%! assert (size ([z30 z30 z30]), [3 0])

--- a/inst/@sym/subs.m
+++ b/inst/@sym/subs.m
@@ -257,13 +257,13 @@ function g = subs(f, in, out)
     'sizes.discard((1, 1))'
     'assert len(sizes) == 1, "all substitions must be same size or scalar"'
     'm, n = sizes.pop()'
-    'g = [[0]*n for i in range(m)]'
+    'g = []'
     'for i in range(m):'
     '    for j in range(n):'
     '        yyy = [y[i, j] if y.is_Matrix else y for y in yy]'
     '        sublist = list(zip(xx, yyy))'
-    '        g[i][j] = f.subs(sublist, simultaneous=True).doit()'
-    'return make_2d_sym(g)'
+    '        g.append(f.subs(sublist, simultaneous=True).doit())'
+    'return _make_2d_sym(g, shape=(m, n))'
   };
 
   g = pycall_sympy__ (cmd, f, in, out);
@@ -460,3 +460,13 @@ end
 %! g = subs (f);
 %! syms x
 %! assert (isequal (g, 6*x*y))
+
+%!test
+%! % issue #1236, correct empty sizes
+%! syms x
+%! g = subs (x, x, zeros (0, 0));
+%! assert (size (g), [0 0])
+%! g = subs (x, x, zeros (0, 3));
+%! assert (size (g), [0 3])
+%! g = subs (x, x, zeros (3, 0));
+%! assert (size (g), [3 0])

--- a/inst/@sym/vertcat.m
+++ b/inst/@sym/vertcat.m
@@ -1,4 +1,4 @@
-%% Copyright (C) 2014-2017, 2019 Colin B. Macdonald
+%% Copyright (C) 2014-2017, 2019, 2022 Colin B. Macdonald
 %% Copyright (C) 2022 Alex Vong
 %%
 %% This file is part of OctSymPy.
@@ -123,12 +123,6 @@ end
 %! a = [v; []; []];
 %! assert (isequal (a, v))
 
-%!xtest
-%! % FIXME: is this Octave bug? worth worrying about
-%! syms x
-%! a = [x; [] []];
-%! assert (isequal (a, x))
-
 %!test
 %! % more empty vectors
 %! v = [sym(1) sym(2)];
@@ -139,6 +133,14 @@ end
 %! v = [sym(1) sym(2)];
 %! q = sym(ones(0, 3));
 %! w = vertcat(v, q);
+
+%!error <ShapeError>
+%! z03 = sym (zeros (0, 3));
+%! z04 = sym (zeros (0, 4));
+%! % Note Issue #1238: unclear error message:
+%! % [z03; z04];
+%! % but this gives the ShapeError
+%! vertcat(z03, z04);
 
 %!test
 %! % Octave 3.6 bug: should pass on 3.8.1 and matlab
@@ -157,3 +159,29 @@ end
 %! A = sym ([1 2]);
 %! B = simplify (A);
 %! assert (isequal ([B; A], [A; B]))
+
+%!xtest
+%! % issue #1236, correct empty sizes
+%! syms x
+%! z00 = sym (zeros (0, 0));
+%! z30 = sym (zeros (3, 0));
+%! z40 = sym (zeros (4, 0));
+%! z03 = sym (zeros (0, 3));
+%! assert (size ([z00; z00]), [0 0])
+%! assert (size ([z00; z30]), [3 0])
+%! assert (size ([z30; z30]), [6 0])
+%! assert (size ([z30; z40]), [7 0])
+%! assert (size ([z30; z00; z30]), [6 0])
+%! assert (size ([z03; z03]), [0 3])
+%! assert (size ([z03; z03; z03]), [0 3])
+
+%!test
+%! % special case for the 0x0 empty: no error
+%! z00 = sym (zeros (0, 0));
+%! z03 = sym (zeros (0, 3));
+%! [z00; z03];
+
+%!test
+%! syms x
+%! a = [x; sym([]) []];
+%! assert (isequal (a, x))

--- a/inst/@sym/vertcat.m
+++ b/inst/@sym/vertcat.m
@@ -49,18 +49,20 @@ function h = vertcat(varargin)
          '    return isinstance(x, (MatrixBase, NDimArray))'
          'def number_of_columns(x):'
          '    return x.shape[1] if is_matrix_or_array(x) else 1'
+         'def number_of_rows(x):'
+         '    return x.shape[0] if is_matrix_or_array(x) else 1'
          'def all_equal(*ls):'
          '    return True if ls == [] else all(ls[0] == x for x in ls[1:])'
-         'def as_list_of_list(x):'
-         '    return x.tolist() if is_matrix_or_array(x) else [[x]]'
          'args = [x for x in _ins if x != zeros(0, 0)] # remove 0x0 matrices'
          'ncols = [number_of_columns(x) for x in args]'
+         'nrows = [number_of_rows(x) for x in args]'
          'if not all_equal(*ncols):'
          '    msg = "vertcat: all inputs must have the same number of columns"'
          '    raise ShapeError(msg)'
-         'CCC = [as_list_of_list(x) for x in args]'
+         'ncol = 0 if not ncols else ncols[0]'
+         'CCC = [flatten(x, levels=1) if is_matrix_or_array(x) else [x] for x in args]'
          'CC = flatten(CCC, levels=1)'
-         'return make_2d_sym(CC)'};
+         'return _make_2d_sym(CC, shape=(sum(nrows), ncol))' };
 
   args = cellfun (@sym, varargin, 'UniformOutput', false);
   h = pycall_sympy__ (cmd, args{:});
@@ -160,7 +162,7 @@ end
 %! B = simplify (A);
 %! assert (isequal ([B; A], [A; B]))
 
-%!xtest
+%!test
 %! % issue #1236, correct empty sizes
 %! syms x
 %! z00 = sym (zeros (0, 0));

--- a/inst/@sym/vertcat.m
+++ b/inst/@sym/vertcat.m
@@ -145,6 +145,17 @@ end
 %! vertcat(z03, z04);
 
 %!test
+%! % special case for the 0x0 empty: no error
+%! z00 = sym (zeros (0, 0));
+%! z03 = sym (zeros (0, 3));
+%! [z00; z03];
+
+%!test
+%! syms x
+%! a = [x; sym([]) []];
+%! assert (isequal (a, x))
+
+%!test
 %! % Octave 3.6 bug: should pass on 3.8.1 and matlab
 %! a = [sym(1) 2];
 %! assert (isequal ( [a; [3 4]] , [1 2; 3 4]  ))
@@ -176,14 +187,3 @@ end
 %! assert (size ([z30; z00; z30]), [6 0])
 %! assert (size ([z03; z03]), [0 3])
 %! assert (size ([z03; z03; z03]), [0 3])
-
-%!test
-%! % special case for the 0x0 empty: no error
-%! z00 = sym (zeros (0, 0));
-%! z03 = sym (zeros (0, 3));
-%! [z00; z03];
-
-%!test
-%! syms x
-%! a = [x; sym([]) []];
-%! assert (isequal (a, x))


### PR DESCRIPTION
Fixes #1236.  Or at least the part of #1236 that pertains to `subs`. Added new tests.