### PR TITLE
Port helpers from list-of-lists to flat+shape

### DIFF
--- a/inst/@sym/private/mat_rclist_access.m
+++ b/inst/@sym/private/mat_rclist_access.m
@@ -35,9 +35,9 @@ function z = mat_rclist_access(A, r, c)
 
   cmd = {'(A, rr, cc) = _ins'
          'AA = A.tolist() if isinstance(A, (MatrixBase, NDimArray)) else [[A]]'
-         'MM = [[AA[i][j]] for i, j in zip(rr, cc)]'
-         'M = make_2d_sym(MM)'
-         'return M,'};
+         'M = [AA[i][j] for i, j in zip(rr, cc)]'
+         'return _make_2d_sym(M, shape=(len(rr), 1)),'
+	};
 
   rr = num2cell(int32(r-1));
   cc = num2cell(int32(c-1));

--- a/inst/@sym/private/mat_rclist_asgn.m
+++ b/inst/@sym/private/mat_rclist_asgn.m
@@ -58,7 +58,7 @@ function z = mat_rclist_asgn(A, r, c, B)
   % Easy trick to copy A into larger matrix AA:
   %    AA = sp.Matrix.zeros(n, m)
   %    AA[0, 0] = A
-  % Also usefil: .copyin_matrix
+  % Also useful: .copyin_matrix
 
   cmd = {'(A, rr, cc, b) = _ins'
          'assert A == [] or not isinstance(A, list), "unexpectedly non-empty list: report bug!"'


### PR DESCRIPTION
Related to #1236.  I don't see a problem with the list-of-lists approach, but there are only 2 routines using it so we can delete some code if we port them to flat + shape.

@alexvong1995 can you port `@sym/private/mat_rclist_access.m` to `_make_2d_sym`?  And then delete the `make_2d_sym` function.