### PR TITLE
Fixes for SymPy 1.12

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -56,26 +56,26 @@ jobs:
       fail-fast: true
       matrix:
         octave: [8.1.0]
-        sympy: [1.4, 1.5.1, 1.6.2, 1.7.1, 1.8, 1.9, 1.10.1, 1.11.1]
+        sympy: [1.4, 1.5.1, 1.6.2, 1.7.1, 1.8, 1.9, 1.10.1, 1.11.1, 1.12rc1]
         include:
           - octave: 5.1.0
             sympy: 1.8
           - octave: 5.2.0
             sympy: 1.8
           - octave: 6.1.0
-            sympy: 1.11.1
+            sympy: 1.12rc1
           - octave: 6.2.0
-            sympy: 1.11.1
+            sympy: 1.12rc1
           - octave: 6.3.0
-            sympy: 1.11.1
+            sympy: 1.12rc1
           - octave: 6.4.0
-            sympy: 1.11.1
+            sympy: 1.12rc1
           - octave: 7.1.0
-            sympy: 1.11.1
+            sympy: 1.12rc1
           - octave: 7.2.0
-            sympy: 1.11.1
+            sympy: 1.12rc1
           - octave: 7.3.0
-            sympy: 1.11.1
+            sympy: 1.12rc1
     steps:
       - uses: actions/checkout@v3
       - name: Container setup
@@ -120,7 +120,7 @@ jobs:
       fail-fast: true
       matrix:
         octave: [7.3.0]
-        sympy: [1.9, 1.10.1, 1.11.1]
+        sympy: [1.11.1]
     steps:
       - uses: actions/checkout@v3
       - name: Container setup

--- a/NEWS
+++ b/NEWS
@@ -10,6 +10,11 @@ octsympy 3.0.1+
 
   * Indexing bounds checking to support Octave 8.
 
+  * Fix assumptions on SymPy 1.12.
+
+  * Other misc fixes and changes for SymPy 1.12.
+
+
 
 octsympy 3.0.1 (2022-08-09)
 ===========================

--- a/inst/@sym/euler.m
+++ b/inst/@sym/euler.m
@@ -1,4 +1,4 @@
-%% Copyright (C) 2017-2019, 2022 Colin B. Macdonald
+%% Copyright (C) 2017-2019, 2022-2023 Colin B. Macdonald
 %%
 %% This file is part of OctSymPy.
 %%
@@ -112,5 +112,14 @@ end
 %!     vpa('4270.98066989140286451493108809574')*1i;
 %! z = vpa (exp(1), 32) + vpa(pi, 32)/13*1i;
 %! B = euler (13, z);
-%! relerr = double(abs((B - A)/A));
-%! assert (abs(relerr) < 2e-31);
+%! relerr = abs(double(abs((B - A)/A)));
+%! assert (relerr < 20*eps);
+
+%!xtest
+%! % as above, high-prec result broken in 1.12: https://github.com/sympy/sympy/issues/24156
+%! A = vpa('1623.14184180556920918624604530515') + ...
+%!     vpa('4270.98066989140286451493108809574')*1i;
+%! z = vpa (exp(1), 32) + vpa(pi, 32)/13*1i;
+%! B = euler (13, z);
+%! relerr = abs(double(abs((B - A)/A)));
+%! assert (relerr < 2e-31);

--- a/inst/@sym/ilaplace.m
+++ b/inst/@sym/ilaplace.m
@@ -192,7 +192,7 @@ end
 %! syms c positive
 %! calc = ilaplace (2*exp (-c*s), s, t);
 %! want = 2*dirac (t - c);
-%! assert (isequal (calc, want))
+%! assert (isAlways (calc == want))
 
 %!error <more than one> ilaplace (sym('s', 'positive')*sym('s'))
 

--- a/inst/@sym/ilaplace.m
+++ b/inst/@sym/ilaplace.m
@@ -1,5 +1,5 @@
 %% Copyright (C) 2014-2016 Andrés Prieto
-%% Copyright (C) 2015-2016, 2018-2019, 2022 Colin Macdonald
+%% Copyright (C) 2015-2016, 2018-2019, 2022-2023 Colin Macdonald
 %%
 %% This file is part of OctSymPy.
 %%
@@ -181,10 +181,18 @@ end
 
 %!test
 %! % Delta dirac test 2
-%! syms s c
-%! t = sym('t', 'positive');
-%! assert (isequal (ilaplace (5*exp(-3*s) + 2*exp(c*s) - 2*exp(-2*s)/s,t), ...
-%!                  5*dirac(t-3) + 2*dirac(c+t) - 2*heaviside(t-2)))
+%! syms s t
+%! calc = ilaplace (5*exp (-3*s) - 2*exp (-2*s)/s, s, t);
+%! want = 5*dirac (t-3) - 2*heaviside (t-2);
+%! assert (isequal (calc, want))
+
+%!test
+%! % Delta dirac test 3, coefficient
+%! syms s t
+%! syms c positive
+%! calc = ilaplace (2*exp (-c*s), s, t);
+%! want = 2*dirac (t - c);
+%! assert (isequal (calc, want))
 
 %!error <more than one> ilaplace (sym('s', 'positive')*sym('s'))
 


### PR DESCRIPTION
* fix for incorrect ilaplace tests

* workaround worse `euler` function for high-precision complex evaluation: linked `xtest` to upstream issue https://github.com/sympy/sympy/issues/24156