### PR TITLE
Update Laplace docs and tests for later SymPy

### DIFF
--- a/inst/@sym/ilaplace.m
+++ b/inst/@sym/ilaplace.m
@@ -64,10 +64,12 @@
 %% @end group
 %% @end example
 %%
-%% More abstract expressions can be transformed:
+%% If the underlying SymPy library is new enough,
+%% more abstract expressions can be transformed:
 %% @example
 %% syms s y(t)
 %% A = s*laplace (y(t), t, s) - y(0);
+%% @c doctest: +SKIP_UNLESS(pycall_sympy__ ('return Version(spver) >= Version("1.15.0")'))
 %% ilaplace (A)
 %%   @result{} (sym)
 %%       d
@@ -223,14 +225,20 @@ end
 
 %!test
 %! % first derivative round-trip
+%! if (pycall_sympy__ ('return Version(spver) >= Version("1.15.0")'))
 %! syms t positive
 %! syms s f(t)
 %! A = laplace (diff (f));
-%! assert (isequal (ilaplace (A), diff (f(t))))
+%! B = ilaplace (A);
+%! assert (isequal (B, diff (f(t))))
+%! end
 
 %!test
 %! % second derivative round-trip
+%! if (pycall_sympy__ ('return Version(spver) >= Version("1.15.0")'))
 %! syms t positive
 %! syms s f(t)
 %! A = laplace (diff (f(t), 2));
-%! assert (isequal (ilaplace (A), diff (f(t), 2)))
+%! B = ilaplace (A);
+%! assert (isequal (B, diff (f(t), 2)))
+%! end

--- a/inst/@sym/ilaplace.m
+++ b/inst/@sym/ilaplace.m
@@ -1,6 +1,6 @@
 %% SPDX-License-Identifier: GPL-3.0-or-later
 %% Copyright (C) 2014-2016 Andrés Prieto
-%% Copyright (C) 2015-2016, 2018-2019, 2022-2024 Colin Macdonald
+%% Copyright (C) 2015-2016, 2018-2019, 2022-2024, 2026 Colin Macdonald
 %%
 %% This file is part of OctSymPy.
 %%
@@ -62,6 +62,17 @@
 %% ilaplace(1/s^2, s, t)
 %%   @result{} (sym) t
 %% @end group
+%% @end example
+%%
+%% More abstract expressions can be transformed:
+%% @example
+%% syms s y(t)
+%% A = s*laplace (y(t), t, s) - y(0);
+%% ilaplace (A)
+%%   @result{} (sym)
+%%       d
+%%       ──(y(t))
+%%       dt
 %% @end example
 %%
 %% By default the output is a function of @code{t} (or @code{x} if the
@@ -209,3 +220,17 @@ end
 %! syms s real
 %! syms x t
 %! assert (isequal (ilaplace (x/s^2, t), x*t*heaviside(t)))
+
+%!test
+%! % first derivative round-trip
+%! syms t positive
+%! syms s f(t)
+%! A = laplace (diff (f));
+%! assert (isequal (ilaplace (A), diff (f(t))))
+
+%!test
+%! % second derivative round-trip
+%! syms t positive
+%! syms s f(t)
+%! A = laplace (diff (f(t), 2));
+%! assert (isequal (ilaplace (A), diff (f(t), 2)))

--- a/inst/@sym/laplace.m
+++ b/inst/@sym/laplace.m
@@ -66,6 +66,7 @@
 %% The Laplace transform of a derivative results in an
 %% algebraic expression in the transformed function:
 %% @example
+%% @c doctest: +SKIP_UNLESS(pycall_sympy__ ('return Version(spver) >= Version("1.12")'))
 %% laplace (diff (y(t)))
 %%   @result{} (sym) s⋅LaplaceTransform(y(t), t, s) - y(0)
 %% @end example
@@ -225,7 +226,7 @@ end
 
 %!test
 %! % Differential operator to algebraic
-%! if (pycall_sympy__ ('return Version(spver) >= Version("1.10.1")'))
+%! if (pycall_sympy__ ('return Version(spver) >= Version("1.12")'))
 %! syms s f(t)
 %! assert (logical (laplace (diff (f(t),t),t,s) == s*laplace (f(t),t,s) - f(0) ))
 %! end

--- a/inst/@sym/laplace.m
+++ b/inst/@sym/laplace.m
@@ -1,6 +1,6 @@
 %% SPDX-License-Identifier: GPL-3.0-or-later
 %% Copyright (C) 2014-2016 Andrés Prieto
-%% Copyright (C) 2015-2016, 2019, 2024 Colin Macdonald
+%% Copyright (C) 2015-2016, 2019, 2024, 2026 Colin Macdonald
 %%
 %% This file is part of OctSymPy.
 %%
@@ -56,6 +56,20 @@
 %% @end group
 %% @end example
 %%
+%% You can take the Laplace transform of an abstract function:
+%% @example
+%% syms y(t)
+%% laplace (y(t))
+%%   @result{} (sym) LaplaceTransform(y(t), t, s)
+%% @end example
+%%
+%% The Laplace transform of a derivative results in an
+%% algebraic expression in the transformed function:
+%% @example
+%% laplace (diff (y(t)))
+%%   @result{} (sym) s⋅LaplaceTransform(y(t), t, s) - y(0)
+%% @end example
+%%
 %% By default the output is a function of @code{s} (or @code{z} if the Laplace
 %% transform happens to be with respect to @code{s}).  This can be overridden
 %% by specifying @var{s}.  For example:
@@ -101,7 +115,6 @@
 function F = laplace(varargin)
 
   % FIXME: it only works for scalar functions
-  % FIXME: it doesn't handle diff call (see SMT transform of diff calls)
 
   f = sym(varargin{1});
   if (nargin == 1 || nargin == 2)
@@ -210,11 +223,12 @@ end
 %! assert (isequal (laplace(dirac(t-3)), exp(-3*s)))
 %! assert (isequal (laplace((t-3)*heaviside(t-3)), exp(-3*s)/s^2))
 
-%!xtest
+%!test
 %! % Differential operator to algebraic
-%! % SymPy cannot evaluate? (Issue #170)
+%! if (pycall_sympy__ ('return Version(spver) >= Version("1.10.1")'))
 %! syms s f(t)
-%! assert(logical( laplace(diff(f(t),t),t,s) == s*laplace(f(t),t,s)-f(0) ))
+%! assert (logical (laplace (diff (f(t),t),t,s) == s*laplace (f(t),t,s) - f(0) ))
+%! end
 
 %!test
 %! % https://github.com/gnu-octave/symbolic/issues/1295


### PR DESCRIPTION
Laplace transforms of derivatives seem to work now, with more recent versions of SymPy, update tests and docs.

Fixes #170.